### PR TITLE
feat: Stream Deck control server (mute, deafen, disconnect)

### DIFF
--- a/scripts/streamdeck/README.md
+++ b/scripts/streamdeck/README.md
@@ -1,0 +1,76 @@
+# Stream Deck Integration for Mutiny Desktop
+
+Control Mutiny (mute, deafen, disconnect) from a Stream Deck on Windows.
+
+## How It Works
+
+When Mutiny Desktop starts, it spins up a tiny HTTP server on `127.0.0.1:7423`.
+Stream Deck buttons run a PowerShell script that hits an endpoint, which injects
+JavaScript into the Mutiny renderer to interact with the voice UI.
+
+## Setup
+
+### 1. Copy the Script
+
+Copy `mutiny-control.ps1` somewhere permanent on papayabox, e.g.:
+
+```
+C:\Users\<you>\Documents\StreamDeck\mutiny-control.ps1
+```
+
+### 2. Configure Each Stream Deck Button
+
+In Stream Deck software, for each button:
+
+- **Action:** `System → Open` (or any "Run Application" action)
+- **App / Path:** `powershell.exe`
+- **Arguments:** `-WindowStyle Hidden -File "C:\Users\<you>\Documents\StreamDeck\mutiny-control.ps1" -Command <command>`
+
+Replace `<command>` with one of:
+
+| Command         | Effect                              |
+|-----------------|-------------------------------------|
+| `toggle-mute`   | Mute / unmute your microphone       |
+| `toggle-deafen` | Deafen / undeafen                   |
+| `disconnect`    | Leave the current voice channel     |
+| `focus`         | Bring the Mutiny window to the front|
+| `ping`          | Health check (useful for testing)   |
+
+### 3. Test It
+
+Open PowerShell and run:
+
+```powershell
+.\mutiny-control.ps1 -Command ping
+# Expected: OK: {"ok":true,"result":"pong"}
+
+.\mutiny-control.ps1 -Command toggle-mute
+# Expected: OK: {"ok":true,"result":"clicked:title"}
+```
+
+If you get "not reachable", make sure Mutiny Desktop is running.
+
+## Troubleshooting
+
+**"not reachable" error**
+Mutiny isn't running, or it's an older build without the control server.
+Update to the latest release and try again.
+
+**`result: "not-found"`**
+Mutiny is running but you're not currently in a voice channel (nothing to mute).
+Join a voice channel first, then press the button.
+
+**Windows Firewall prompt**
+The server only binds to `127.0.0.1` so no firewall rules are needed —
+Windows shouldn't prompt, but if it does, deny external access (local-only is fine).
+
+## Adding More Buttons
+
+You can create separate `.ps1` wrappers for each command if you prefer not to
+use parameters, e.g. `mute.ps1`:
+
+```powershell
+& "$PSScriptRoot\mutiny-control.ps1" -Command toggle-mute
+```
+
+Then point the Stream Deck button at `mute.ps1` with no arguments.

--- a/scripts/streamdeck/mutiny-control.ps1
+++ b/scripts/streamdeck/mutiny-control.ps1
@@ -1,0 +1,33 @@
+# mutiny-control.ps1
+# Sends a command to the Mutiny Stream Deck control server.
+#
+# Usage (from Stream Deck "System: Open" or "Run" action):
+#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-mute
+#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-deafen
+#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command disconnect
+#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command focus
+#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command ping
+
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("toggle-mute", "mute", "toggle-deafen", "deafen", "disconnect", "leave", "focus", "ping")]
+    [string]$Command
+)
+
+$Port    = 7423
+$BaseUrl = "http://127.0.0.1:$Port"
+$Url     = "$BaseUrl/$Command"
+
+try {
+    $response = Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 3 -ErrorAction Stop
+    Write-Host "OK: $($response | ConvertTo-Json -Compress)"
+    exit 0
+} catch {
+    $code = $_.Exception.Response?.StatusCode?.value__
+    if ($null -eq $code) {
+        Write-Warning "Mutiny control server not reachable (is Mutiny running?)"
+    } else {
+        Write-Warning "Mutiny returned HTTP $code for /$Command"
+    }
+    exit 1
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import started from "electron-squirrel-startup";
 
 import { autoLaunch } from "./native/autoLaunch";
 import { config } from "./native/config";
+import { initControlServer } from "./native/controlServer";
 import { initDiscordRpc } from "./native/discordRpc";
 import { showScreenPicker } from "./native/screenPicker";
 import { initTray } from "./native/tray";
@@ -115,6 +116,7 @@ if (acquiredLock) {
     createMainWindow();
     initTray();
     initDiscordRpc();
+    initControlServer();
 
     // Windows specific fix for notifications
     if (process.platform === "win32") {

--- a/src/native/controlServer.ts
+++ b/src/native/controlServer.ts
@@ -1,0 +1,182 @@
+/**
+ * Stream Deck Control Server
+ *
+ * Tiny HTTP server (127.0.0.1:7423) that accepts commands from Stream Deck
+ * PowerShell scripts and forwards them to the Mutiny renderer via executeJavaScript.
+ *
+ * Endpoints:
+ *   GET /ping           — health check, returns "pong"
+ *   GET /toggle-mute    — toggle microphone mute
+ *   GET /toggle-deafen  — toggle deafen
+ *   GET /disconnect     — leave the current voice channel
+ *   GET /focus          — bring the Mutiny window to front
+ *
+ * All endpoints respond with JSON: { ok: true, result: string }
+ * Only 127.0.0.1 connections are accepted.
+ */
+
+import * as http from "http";
+
+import { mainWindow } from "./window";
+
+const PORT = 7423;
+const HOST = "127.0.0.1";
+
+// JS injected into the renderer for each command.
+// Uses multiple selector strategies for resilience across Revolt frontend versions.
+const SCRIPTS = {
+  toggleMute: `
+    (function () {
+      // Strategy 1: tooltip title (Revite / classic Revolt)
+      const byTitle = document.querySelector(
+        'button[title*="Mute microphone"], button[title*="Unmute microphone"]'
+      );
+      if (byTitle) { byTitle.click(); return 'clicked:title'; }
+
+      // Strategy 2: aria-label
+      const byAria = document.querySelector(
+        'button[aria-label*="ute microphone"]'
+      );
+      if (byAria) { byAria.click(); return 'clicked:aria'; }
+
+      // Strategy 3: data-tooltip (newer Revolt SolidJS frontend)
+      const byTooltip = document.querySelector(
+        '[data-tooltip*="ute microphone"]'
+      );
+      if (byTooltip) { byTooltip.click(); return 'clicked:data-tooltip'; }
+
+      // Strategy 4: find the voice panel and click the first non-disconnect button
+      const panel = document.querySelector(
+        '[class*="voice" i] .actions, [class*="VoiceHeader"] .actions, [class*="call-controls"]'
+      );
+      if (panel) {
+        const btns = [...panel.querySelectorAll('button')];
+        // Disconnect button usually has a phone/hangup icon — skip it
+        const micBtn = btns.find(b => !b.querySelector('[class*="phone" i], [class*="hangup" i]'));
+        if (micBtn) { micBtn.click(); return 'clicked:panel-button'; }
+      }
+
+      return 'not-found';
+    })()
+  `,
+
+  toggleDeafen: `
+    (function () {
+      const byTitle = document.querySelector(
+        'button[title*="Deafen"], button[title*="Undeafen"]'
+      );
+      if (byTitle) { byTitle.click(); return 'clicked:title'; }
+
+      const byAria = document.querySelector(
+        'button[aria-label*="eafen"]'
+      );
+      if (byAria) { byAria.click(); return 'clicked:aria'; }
+
+      const byTooltip = document.querySelector('[data-tooltip*="eafen"]');
+      if (byTooltip) { byTooltip.click(); return 'clicked:data-tooltip'; }
+
+      return 'not-found';
+    })()
+  `,
+
+  disconnect: `
+    (function () {
+      const byTitle = document.querySelector(
+        'button[title*="Disconnect"], button[title*="Leave"], button[title*="Hang up"]'
+      );
+      if (byTitle) { byTitle.click(); return 'clicked:title'; }
+
+      const byAria = document.querySelector(
+        'button[aria-label*="isconnect"], button[aria-label*="eave"]'
+      );
+      if (byAria) { byAria.click(); return 'clicked:aria'; }
+
+      return 'not-found';
+    })()
+  `,
+} as const;
+
+type CommandKey = keyof typeof SCRIPTS;
+
+const ROUTES: Record<string, CommandKey | "focus" | "ping"> = {
+  "/toggle-mute": "toggleMute",
+  "/mute": "toggleMute",
+  "/toggle-deafen": "toggleDeafen",
+  "/deafen": "toggleDeafen",
+  "/disconnect": "disconnect",
+  "/leave": "disconnect",
+  "/focus": "focus",
+  "/ping": "ping",
+};
+
+export function initControlServer(): void {
+  const server = http.createServer(async (req, res) => {
+    // Reject non-local connections
+    const remote = req.socket.remoteAddress ?? "";
+    if (!["127.0.0.1", "::1", "::ffff:127.0.0.1"].includes(remote)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Forbidden" }));
+      return;
+    }
+
+    const path = (req.url ?? "/").split("?")[0];
+    const action = ROUTES[path];
+
+    if (!action) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "Unknown command",
+          path,
+          available: Object.keys(ROUTES),
+        }),
+      );
+      return;
+    }
+
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Mutiny window not available" }));
+      return;
+    }
+
+    try {
+      let result: string;
+
+      if (action === "ping") {
+        result = "pong";
+      } else if (action === "focus") {
+        mainWindow.show();
+        mainWindow.focus();
+        result = "focused";
+      } else {
+        result = await mainWindow.webContents.executeJavaScript(
+          SCRIPTS[action],
+        );
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, result }));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: message }));
+    }
+  });
+
+  server.listen(PORT, HOST, () => {
+    console.log(
+      `[mutiny] Stream Deck control server → http://${HOST}:${PORT}`,
+    );
+  });
+
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.warn(
+        `[mutiny] Control server: port ${PORT} already in use — skipping`,
+      );
+    } else {
+      console.error("[mutiny] Control server error:", err);
+    }
+  });
+}


### PR DESCRIPTION
## What

Adds a tiny localhost HTTP server to the Electron main process so a Stream Deck Mini (or any HTTP-capable controller) can control Mutiny voice without needing an official plugin.

## Endpoints

| Path | Effect |
|------|--------|
| `GET /toggle-mute` | Mute / unmute microphone |
| `GET /toggle-deafen` | Deafen / undeafen |
| `GET /disconnect` | Leave voice channel |
| `GET /focus` | Bring window to front |
| `GET /ping` | Health check |

Server binds to `127.0.0.1:7423` only — no firewall rules needed.

## How It Works

The server injects JS into the renderer via `executeJavaScript`. Selectors use multiple fallback strategies (tooltip title → aria-label → data-tooltip → DOM scan) so it stays resilient to frontend changes.

## Stream Deck Setup (Windows / papayabox)

See `scripts/streamdeck/README.md`. Short version:

1. Copy `mutiny-control.ps1` to your machine
2. In Stream Deck: **Action → System → Open** → `powershell.exe` with args:
   ```
   -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-mute
   ```
3. Test with `ping` first, then `toggle-mute`

## Files Changed

- `src/native/controlServer.ts` — new HTTP server module
- `src/main.ts` — `initControlServer()` called after window init
- `scripts/streamdeck/mutiny-control.ps1` — Stream Deck PowerShell script
- `scripts/streamdeck/README.md` — setup guide