### PR TITLE
security: add Content-Security-Policy header to Electron window

### DIFF
--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -114,6 +114,18 @@ export function createMainWindow() {
     }
   });
 
+  // enforce Content Security Policy
+  mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        "Content-Security-Policy": [
+          "default-src 'self' 'unsafe-inline' data: https://beta.revolt.chat https://*.revolt.chat; media-src 'self' blob: data: https:; connect-src 'self' wss: https:;",
+        ],
+      },
+    });
+  });
+
   // send the config
   mainWindow.webContents.on("did-finish-load", () => config.sync());
 


### PR DESCRIPTION
Closes MUT-12.

Adds a Content-Security-Policy header to the Electron window to prevent XSS via injected scripts. The CSP restricts content sources to trusted origins (self, revolt.chat domains) and controls media, script, and WebSocket connections.