### PR TITLE
fix: complete desktop reliability sprint (#21-#30)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,8 @@
     "plugin:import/electron",
     "plugin:import/typescript"
   ],
-  "parser": "@typescript-eslint/parser"
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "import/no-unresolved": ["error", { "ignore": ["\\?asset$"] }]
+  }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
       - "tsconfig.json"
       - ".eslintrc.json"
       - ".github/workflows/build.yml"
+      - ".github/workflows/release.yml"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,16 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test
 
       - name: Build
         run: pnpm run package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,22 @@
 # Electron desktop app is deprecated.
 # Mutiny has moved to native iOS/macOS (SwiftUI).
-# This workflow is preserved for reference but will not run automatically.
-# Trigger manually via workflow_dispatch if ever needed.
+# Validate changes to the deprecated client on pull requests, without restoring
+# continuous branch builds or automatic releases.
 
 name: Build (Electron — deprecated)
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "forge.config.ts"
+      - "tsconfig.json"
+      - ".eslintrc.json"
+      - ".github/workflows/build.yml"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify requested version matches package metadata
+        shell: bash
+        run: |
+          package_version="$(node -p 'require("./package.json").version')"
+          test "${{ inputs.version }}" = "v${package_version}" || {
+            echo "Requested release ${{ inputs.version }} does not match package.json v${package_version}" >&2
+            exit 1
+          }
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test
+
       - name: Build and package
         run: pnpm run make
         env:
@@ -99,6 +117,7 @@ jobs:
           for f in release/Mutiny-darwin-arm64-*.zip; do [ -f "$f" ] && cp "$f" release/Mutiny-darwin-arm64.zip; done
           for f in release/Mutiny-win32-x64-*.zip; do [ -f "$f" ] && cp "$f" release/Mutiny-win32-x64.zip; done
           for f in release/mutiny-desktop-setup.exe; do [ -f "$f" ] && cp "$f" release/Mutiny-setup.exe; done
+          (cd release && sha256sum ./* > SHA256SUMS.txt)
           ls -la release/
 
       - name: Create GitHub Release

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,7 +7,7 @@ import { MakerZIP } from "@electron-forge/maker-zip";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { PublisherGithub } from "@electron-forge/publisher-github";
-import type { ForgeConfig, ForgeHookFn } from "@electron-forge/shared-types";
+import type { ForgeConfig } from "@electron-forge/shared-types";
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mutiny-desktop",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mutiny-desktop",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "dependencies": {
         "@electron-forge/maker-appx": "^7.9.0",
         "auto-launch": "^5.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.2.2",
       "dependencies": {
         "@electron-forge/maker-appx": "^7.9.0",
-        "@homebridge/dbus-native": "^0.7.2",
         "auto-launch": "^5.0.6",
         "bufferutil": "^4.0.9",
         "deepfilternet3-noise-filter": "^1.2.1",
@@ -41,8 +40,9 @@
         "eslint-plugin-import": "^2.32.0",
         "json-schema-typed": "^8.0.1",
         "prettier": "^3.6.2",
-        "typescript": "~4.5.4",
-        "vite": "^5.4.20"
+        "typescript": "~5.9.3",
+        "vite": "^5.4.20",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -175,7 +175,8 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@electron-forge/cli": {
       "version": "7.11.1",
@@ -651,7 +652,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1507,23 +1507,6 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT"
     },
-    "node_modules/@homebridge/dbus-native": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.4.tgz",
-      "integrity": "sha512-DtX16c/NNT/NJBFgy8qu74z/SZuAaS0GJahKIrS9ZZOYUHDtZYr1B4ZdjQlr+1NT7ZcCk6e84O4lAieiJq0Hsw==",
-      "license": "MIT",
-      "dependencies": {
-        "event-stream": "^4.0.1",
-        "hexy": "^0.4.0",
-        "long": "^5.3.2",
-        "minimist": "^1.2.8",
-        "safe-buffer": "^5.1.2",
-        "xml2js": "^0.6.2"
-      },
-      "bin": {
-        "dbus2js": "bin/dbus2js.js"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1706,7 +1689,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1867,13 +1849,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
       "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@livekit/protocol": {
       "version": "1.45.3",
       "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.45.3.tgz",
       "integrity": "sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
@@ -2143,7 +2127,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3086,7 +3069,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -3248,6 +3230,119 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@vscode/sudo-prompt": {
       "version": "9.3.2",
@@ -3452,7 +3547,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3525,7 +3619,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3751,6 +3844,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3952,7 +4055,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4013,12 +4115,21 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
         "node": ">=6.14.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacache": {
@@ -4211,6 +4322,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4233,6 +4361,16 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chownr": {
       "version": "2.0.0",
@@ -4678,6 +4816,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4813,6 +4961,21 @@
         "register-scheme": "github:devsnek/node-register-scheme"
       }
     },
+    "node_modules/discord-rpc/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/discord-rpc/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -4888,12 +5051,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -5761,7 +5918,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6105,6 +6261,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6113,21 +6279,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
       }
     },
     "node_modules/eventemitter3": {
@@ -6255,6 +6406,16 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -6540,12 +6701,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -7085,18 +7240,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hexy": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
-      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
-      "license": "MIT",
-      "bin": {
-        "hexy": "bin/hexy_cmd.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -7995,6 +8138,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8222,6 +8366,7 @@
       "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.7.tgz",
       "integrity": "sha512-8mMNfJ9sPTWT9W5CsV23yJhut4vtw0M4c/AR5diRvLn6XsUDij7Odr6GrI9Oj5/T5vDis4y2JTumMiTweGlqMA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@livekit/mutex": "1.1.1",
         "@livekit/protocol": "1.45.3",
@@ -8241,7 +8386,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
@@ -8522,6 +8668,7 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -8530,11 +8677,12 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -8552,6 +8700,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8593,12 +8751,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
-      "license": "MIT"
     },
     "node_modules/matcher": {
       "version": "3.0.0",
@@ -9540,16 +9692,21 @@
         "node": ">=8"
       }
     },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "license": [
-        "MIT",
-        "Apache2"
-      ],
-      "dependencies": {
-        "through": "~2.3"
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pe-library": {
@@ -9693,7 +9850,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10315,15 +10471,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -10366,13 +10513,15 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
       "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sdp-transform": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
       "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "sdp-verify": "checker.js"
       }
@@ -10571,6 +10720,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10723,18 +10879,6 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -10754,6 +10898,20 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -10766,16 +10924,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "node_modules/string_decoder": {
@@ -11173,7 +11321,8 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tiny-each-async": {
       "version": "2.0.3",
@@ -11182,6 +11331,50 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11403,23 +11596,23 @@
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uint8array-extras": {
@@ -11662,6 +11855,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -11764,6 +12053,7 @@
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
       "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "sdp": "^3.2.0"
       },
@@ -11892,6 +12182,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/winreg": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
@@ -11953,28 +12260,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "install:flatpak": "flatpak --user install out/make/flatpak/x86_64/gg.mutinyapp.mutiny-desktop_stable_x86_64.flatpak",
     "run:flatpak": "flatpak run --socket=session-bus gg.mutinyapp.mutiny-desktop",
     "run:nix": "/usr/bin/env electron-nix ."
@@ -42,15 +44,15 @@
     "eslint-plugin-import": "^2.32.0",
     "json-schema-typed": "^8.0.1",
     "prettier": "^3.6.2",
-    "typescript": "~4.5.4",
-    "vite": "^5.4.20"
+    "typescript": "~5.9.3",
+    "vite": "^5.4.20",
+    "vitest": "^2.1.9"
   },
   "dependencies": {
     "@electron-forge/maker-appx": "^7.9.0",
-    "@homebridge/dbus-native": "^0.7.2",
     "auto-launch": "^5.0.6",
-    "deepfilternet3-noise-filter": "^1.2.1",
     "bufferutil": "^4.0.9",
+    "deepfilternet3-noise-filter": "^1.2.1",
     "discord-rpc": "^4.0.1",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mutiny-desktop",
   "productName": "Mutiny",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Mutiny desktop chat client.",
   "main": ".vite/build/main.js",
   "repository": "warpapaya/mutiny-desktop",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       '@electron-forge/maker-appx':
         specifier: ^7.9.0
         version: 7.9.0
-      '@homebridge/dbus-native':
-        specifier: ^0.7.2
-        version: 0.7.2
       auto-launch:
         specifier: ^5.0.6
         version: 5.0.6
       bufferutil:
         specifier: ^4.0.9
         version: 4.0.9
+      deepfilternet3-noise-filter:
+        specifier: ^1.2.1
+        version: 1.3.0(livekit-client@2.20.1(@types/dom-mediacapture-record@1.0.22))
       discord-rpc:
         specifier: ^4.0.1
         version: 4.0.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@6.0.5)
@@ -80,10 +80,10 @@ importers:
         version: 1.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint@8.57.1)(typescript@4.5.5)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       electron:
         specifier: 38.1.2
         version: 38.1.2
@@ -92,7 +92,7 @@ importers:
         version: 8.57.1
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       json-schema-typed:
         specifier: ^8.0.1
         version: 8.0.1
@@ -100,11 +100,14 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2
       typescript:
-        specifier: ~4.5.4
-        version: 4.5.5
+        specifier: ~5.9.3
+        version: 5.9.3
       vite:
         specifier: ^5.4.20
         version: 5.4.20(@types/node@24.5.2)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.5.2)
 
 packages:
 
@@ -144,6 +147,9 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
 
   '@electron-forge/cli@7.9.0':
     resolution: {integrity: sha512-FIs9rV6gN1v8rY73j/dvhQWF8tht035bN2LatY/z99H2KpWr0lhD03MOkIM2lRgrPEqVTExA4JEl9ja9yXBD3Q==}
@@ -446,10 +452,6 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@homebridge/dbus-native@0.7.2':
-    resolution: {integrity: sha512-BNVe6YNxiy5x/E5/ZXDIWMD6Njv9cjW59PM/1CMpYe0jLAJ8pJN+Tq/JhVs3gXwmTavz2S86/sspmHquChet8A==}
-    hasBin: true
-
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -541,6 +543,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@inquirer/prompts': '>= 3 < 8'
+
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.46.6':
+    resolution: {integrity: sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg==}
 
   '@malept/cross-spawn-promise@1.1.1':
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
@@ -795,6 +803,9 @@ packages:
   '@types/discord-rpc@4.0.9':
     resolution: {integrity: sha512-IW5yPfEzcZRaHTvB/AZOvadMwQihVzxbl6xueuGUr3RBF8VSkzbucCRC/zzS10CEVka7LRGT4C7lXKMbWv8oWQ==}
 
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
+
   '@types/electron-squirrel-startup@1.0.2':
     resolution: {integrity: sha512-AzxnvBzNh8K/0SmxMmZtpJf1/IWoGXLP+pQDuUaVkPyotI8ryvAtBSqgxR/qOSvxWHYWrxkeNsJ+Ca5xOuUxJQ==}
 
@@ -900,6 +911,36 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vscode/sudo-prompt@9.3.1':
     resolution: {integrity: sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==}
@@ -907,6 +948,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -1021,6 +1063,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1092,6 +1138,10 @@ packages:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacache@16.1.3:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -1120,6 +1170,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1130,6 +1184,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -1286,8 +1344,18 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepfilternet3-noise-filter@1.3.0:
+    resolution: {integrity: sha512-yYFUlPuvPguqcd/R6/OSsr0noGqlqOE50JkCWYHogk+PjLj9qrNgwTt5zKraVkKnw0l4+eXJagkz2SUWtUl4sQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      livekit-client: ^2.0.0
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -1339,9 +1407,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  duplexer@0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1414,6 +1479,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1523,19 +1591,27 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  event-stream@4.0.1:
-    resolution: {integrity: sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==}
-
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.2:
     resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
@@ -1616,9 +1692,6 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  from@0.1.7:
-    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -1715,12 +1788,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -1786,11 +1859,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  hexy@0.3.5:
-    resolution: {integrity: sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==}
-    engines: {node: '>=10.4'}
-    hasBin: true
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2024,6 +2092,9 @@ packages:
     resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2079,6 +2150,11 @@ packages:
     resolution: {integrity: sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==}
     engines: {node: '>=16.0.0'}
 
+  livekit-client@2.20.1:
+    resolution: {integrity: sha512-JxooxLFMkdwqTo4XLer+DCij6S3//Z/GuHSjqdhlj94Vtbh1Eayd7Lyq47qkIE86+xVJhqxIdYnq53lg4oPH9w==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
   load-json-file@2.0.0:
     resolution: {integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==}
     engines: {node: '>=4'}
@@ -2112,8 +2188,12 @@ packages:
     resolution: {integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -2123,6 +2203,9 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-fetch-happen@10.2.1:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -2130,9 +2213,6 @@ packages:
   map-age-cleaner@0.1.3:
     resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
     engines: {node: '>=6'}
-
-  map-stream@0.0.7:
-    resolution: {integrity: sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==}
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -2446,8 +2526,12 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pause-stream@0.0.11:
-    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pe-library@1.0.1:
     resolution: {integrity: sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==}
@@ -2657,8 +2741,12 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -2724,6 +2812,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2774,9 +2865,6 @@ packages:
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
 
-  split@1.0.1:
-    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
-
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -2784,12 +2872,15 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  stream-combiner@0.2.2:
-    resolution: {integrity: sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==}
 
   string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
@@ -2876,6 +2967,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -2889,6 +2981,24 @@ packages:
 
   tiny-each-async@2.0.3:
     resolution: {integrity: sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -2917,6 +3027,9 @@ packages:
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -2964,9 +3077,12 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
-    engines: {node: '>=4.2.0'}
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   uint8array-extras@1.5.0:
@@ -3026,6 +3142,11 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.20:
     resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3057,11 +3178,40 @@ packages:
       terser:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webrtc-adapter@9.0.6:
+    resolution: {integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3092,6 +3242,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   winreg@1.2.4:
@@ -3127,14 +3282,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xml2js@0.6.2:
-    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
-    engines: {node: '>=4.0.0'}
-
-  xmlbuilder@11.0.1:
-    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
-    engines: {node: '>=4.0'}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -3222,6 +3369,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@bufbuild/protobuf@1.10.1': {}
 
   '@electron-forge/cli@7.9.0(encoding@0.1.13)':
     dependencies:
@@ -3725,15 +3874,6 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
-  '@homebridge/dbus-native@0.7.2':
-    dependencies:
-      event-stream: 4.0.1
-      hexy: 0.3.5
-      long: 5.3.2
-      minimist: 1.2.8
-      safe-buffer: 5.2.1
-      xml2js: 0.6.2
-
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -3864,6 +4004,12 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 6.0.1
       '@inquirer/type': 1.5.5
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.46.6':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
 
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
@@ -4095,6 +4241,8 @@ snapshots:
     dependencies:
       '@types/events': 3.0.3
 
+  '@types/dom-mediacapture-record@1.0.22': {}
+
   '@types/electron-squirrel-startup@1.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -4141,34 +4289,34 @@ snapshots:
       '@types/node': 22.18.6
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint@8.57.1)(typescript@4.5.5)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.2
-      tsutils: 3.21.0(typescript@4.5.5)
+      tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 4.5.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.5.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 4.5.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4177,21 +4325,21 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@4.5.5)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.5.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 8.57.1
-      tsutils: 3.21.0(typescript@4.5.5)
+      tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 4.5.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.5.5)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -4199,20 +4347,20 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
-      tsutils: 3.21.0(typescript@4.5.5)
+      tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
-      typescript: 4.5.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@4.5.5)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.5.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.7.2
@@ -4226,6 +4374,46 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.20(@types/node@24.5.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.20(@types/node@24.5.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vscode/sudo-prompt@9.3.1': {}
 
@@ -4360,6 +4548,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   async-function@1.0.0: {}
 
   at-least-node@1.0.0: {}
@@ -4433,6 +4623,8 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
+  cac@6.7.14: {}
+
   cacache@16.1.3:
     dependencies:
       '@npmcli/fs': 2.1.2
@@ -4487,6 +4679,14 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -4500,6 +4700,8 @@ snapshots:
       supports-color: 7.2.0
 
   chardet@0.7.0: {}
+
+  check-error@2.1.3: {}
 
   chownr@2.0.0: {}
 
@@ -4648,7 +4850,13 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
+
+  deepfilternet3-noise-filter@1.3.0(livekit-client@2.20.1(@types/dom-mediacapture-record@1.0.22)):
+    dependencies:
+      livekit-client: 2.20.1(@types/dom-mediacapture-record@1.0.22)
 
   defaults@1.0.4:
     dependencies:
@@ -4712,8 +4920,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -4879,6 +5085,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4943,17 +5151,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4964,7 +5172,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.5.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4976,7 +5184,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.5.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5055,19 +5263,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
-  event-stream@4.0.1:
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.0.7
-      pause-stream: 0.0.11
-      split: 1.0.1
-      stream-combiner: 0.2.2
-      through: 2.3.8
-
   eventemitter3@5.0.1: {}
+
+  events@3.3.0: {}
 
   execa@1.0.0:
     dependencies:
@@ -5078,6 +5282,8 @@ snapshots:
       p-finally: 1.0.0
       signal-exit: 3.0.7
       strip-eof: 1.0.0
+
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.2: {}
 
@@ -5172,8 +5378,6 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  from@0.1.7: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -5394,8 +5598,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  hexy@0.3.5: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -5623,6 +5825,8 @@ snapshots:
 
   jiti@2.6.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -5678,6 +5882,19 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 8.1.0
 
+  livekit-client@2.20.1(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.46.6
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.2.3
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.6
+
   load-json-file@2.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -5716,11 +5933,17 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 8.1.0
 
-  long@5.3.2: {}
+  loglevel@1.9.2: {}
+
+  loupe@3.2.1: {}
 
   lowercase-keys@2.0.0: {}
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -5747,8 +5970,6 @@ snapshots:
   map-age-cleaner@0.1.3:
     dependencies:
       p-defer: 1.0.0
-
-  map-stream@0.0.7: {}
 
   matcher@3.0.0:
     dependencies:
@@ -6037,9 +6258,9 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pause-stream@0.0.11:
-    dependencies:
-      through: 2.3.8
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   pe-library@1.0.1: {}
 
@@ -6274,7 +6495,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.1: {}
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
 
   semver-compare@1.0.0:
     optional: true
@@ -6352,6 +6575,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6401,10 +6626,6 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  split@1.0.1:
-    dependencies:
-      through: 2.3.8
-
   sprintf-js@1.1.3:
     optional: true
 
@@ -6412,15 +6633,14 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  stream-combiner@0.2.2:
-    dependencies:
-      duplexer: 0.1.2
-      through: 2.3.8
 
   string-width@2.1.1:
     dependencies:
@@ -6534,10 +6754,21 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  through@2.3.8: {}
+  through@2.3.8:
+    optional: true
 
   tiny-each-async@2.0.3:
     optional: true
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -6570,10 +6801,12 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tsutils@3.21.0(typescript@4.5.5):
+  tslib@2.8.1: {}
+
+  tsutils@3.21.0(typescript@5.9.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.5.5
+      typescript: 5.9.3
 
   type-check@0.4.0:
     dependencies:
@@ -6623,7 +6856,11 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@4.5.5: {}
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 6.6.7
+
+  typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
 
@@ -6679,6 +6916,24 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite-node@2.1.9(@types/node@24.5.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.20(@types/node@24.5.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.20(@types/node@24.5.2):
     dependencies:
       esbuild: 0.21.5
@@ -6688,11 +6943,50 @@ snapshots:
       '@types/node': 24.5.2
       fsevents: 2.3.3
 
+  vitest@2.1.9(@types/node@24.5.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@24.5.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20(@types/node@24.5.2)
+      vite-node: 2.1.9(@types/node@24.5.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
 
   webidl-conversions@3.0.1: {}
+
+  webrtc-adapter@9.0.6:
+    dependencies:
+      sdp: 3.2.2
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6750,6 +7044,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   winreg@1.2.4: {}
 
   word-wrap@1.2.5: {}
@@ -6778,13 +7077,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 6.0.5
-
-  xml2js@0.6.2:
-    dependencies:
-      sax: 1.4.1
-      xmlbuilder: 11.0.1
-
-  xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/scripts/streamdeck/README.md
+++ b/scripts/streamdeck/README.md
@@ -1,76 +1,37 @@
 # Stream Deck Integration for Mutiny Desktop
 
-Control Mutiny (mute, deafen, disconnect) from a Stream Deck on Windows.
-
-## How It Works
-
-When Mutiny Desktop starts, it spins up a tiny HTTP server on `127.0.0.1:7423`.
-Stream Deck buttons run a PowerShell script that hits an endpoint, which injects
-JavaScript into the Mutiny renderer to interact with the voice UI.
+Mutiny exposes a loopback-only control server on `127.0.0.1:7423`. The health
+check is a read-only `GET /ping`; voice and focus commands are authenticated
+`POST` requests. Mutiny creates a new 256-bit session token at startup and
+stores it in the Electron user-data directory as `streamdeck-token`. The token
+is never printed to logs.
 
 ## Setup
 
-### 1. Copy the Script
+Copy `mutiny-control.ps1` to a permanent local path, then configure Stream Deck
+**System → Open** actions to run:
 
-Copy `mutiny-control.ps1` somewhere permanent on papayabox, e.g.:
-
+```text
+powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-mute
 ```
-C:\Users\<you>\Documents\StreamDeck\mutiny-control.ps1
-```
 
-### 2. Configure Each Stream Deck Button
+Supported commands are `toggle-mute`, `toggle-deafen`, `disconnect`, `focus`,
+and `ping` (plus the aliases listed in the script). The script reads the token
+from `%APPDATA%\Mutiny\streamdeck-token`. If your Electron user-data directory
+is customized, pass `-TokenPath "C:\path\to\streamdeck-token"`.
 
-In Stream Deck software, for each button:
-
-- **Action:** `System → Open` (or any "Run Application" action)
-- **App / Path:** `powershell.exe`
-- **Arguments:** `-WindowStyle Hidden -File "C:\Users\<you>\Documents\StreamDeck\mutiny-control.ps1" -Command <command>`
-
-Replace `<command>` with one of:
-
-| Command         | Effect                              |
-|-----------------|-------------------------------------|
-| `toggle-mute`   | Mute / unmute your microphone       |
-| `toggle-deafen` | Deafen / undeafen                   |
-| `disconnect`    | Leave the current voice channel     |
-| `focus`         | Bring the Mutiny window to the front|
-| `ping`          | Health check (useful for testing)   |
-
-### 3. Test It
-
-Open PowerShell and run:
+## Test
 
 ```powershell
 .\mutiny-control.ps1 -Command ping
-# Expected: OK: {"ok":true,"result":"pong"}
-
 .\mutiny-control.ps1 -Command toggle-mute
-# Expected: OK: {"ok":true,"result":"clicked:title"}
 ```
 
-If you get "not reachable", make sure Mutiny Desktop is running.
+Successful commands print `{ "ok": true, ... }`. A `409` response means the
+current hosted client has no matching active call control (for example, the
+user is not in a voice channel). A `401` means the token is missing/stale;
+restart Mutiny and let the script read the newly provisioned token.
 
-## Troubleshooting
-
-**"not reachable" error**
-Mutiny isn't running, or it's an older build without the control server.
-Update to the latest release and try again.
-
-**`result: "not-found"`**
-Mutiny is running but you're not currently in a voice channel (nothing to mute).
-Join a voice channel first, then press the button.
-
-**Windows Firewall prompt**
-The server only binds to `127.0.0.1` so no firewall rules are needed —
-Windows shouldn't prompt, but if it does, deny external access (local-only is fine).
-
-## Adding More Buttons
-
-You can create separate `.ps1` wrappers for each command if you prefer not to
-use parameters, e.g. `mute.ps1`:
-
-```powershell
-& "$PSScriptRoot\mutiny-control.ps1" -Command toggle-mute
-```
-
-Then point the Stream Deck button at `mute.ps1` with no arguments.
+The server intentionally rejects state-changing GETs and all browser-originated
+requests, even when they come from loopback. Do not copy the token into browser
+code, Stream Deck profiles, logs, or screenshots.

--- a/scripts/streamdeck/mutiny-control.ps1
+++ b/scripts/streamdeck/mutiny-control.ps1
@@ -1,31 +1,32 @@
 # mutiny-control.ps1
-# Sends a command to the Mutiny Stream Deck control server.
-#
-# Usage (from Stream Deck "System: Open" or "Run" action):
-#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-mute
-#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command toggle-deafen
-#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command disconnect
-#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command focus
-#   powershell.exe -WindowStyle Hidden -File "C:\path\to\mutiny-control.ps1" -Command ping
-
+# Sends an authenticated command to the Mutiny Stream Deck control server.
 param (
     [Parameter(Mandatory = $true)]
     [ValidateSet("toggle-mute", "mute", "toggle-deafen", "deafen", "disconnect", "leave", "focus", "ping")]
-    [string]$Command
+    [string]$Command,
+    [string]$TokenPath = (Join-Path $env:APPDATA "Mutiny\streamdeck-token")
 )
 
-$Port    = 7423
-$BaseUrl = "http://127.0.0.1:$Port"
-$Url     = "$BaseUrl/$Command"
+$Port = 7423
+$Url = "http://127.0.0.1:$Port/$Command"
 
 try {
-    $response = Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 3 -ErrorAction Stop
+    if ($Command -eq "ping") {
+        $response = Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 3 -ErrorAction Stop
+    } else {
+        if (-not (Test-Path -LiteralPath $TokenPath)) {
+            throw "Mutiny token file not found. Start Mutiny once, or pass -TokenPath."
+        }
+        $token = (Get-Content -LiteralPath $TokenPath -Raw).Trim()
+        $headers = @{ Authorization = "Bearer $token" }
+        $response = Invoke-RestMethod -Uri $Url -Method Post -Headers $headers -TimeoutSec 3 -ErrorAction Stop
+    }
     Write-Host "OK: $($response | ConvertTo-Json -Compress)"
     exit 0
 } catch {
     $code = $_.Exception.Response?.StatusCode?.value__
     if ($null -eq $code) {
-        Write-Warning "Mutiny control server not reachable (is Mutiny running?)"
+        Write-Warning $_.Exception.Message
     } else {
         Write-Warning "Mutiny returned HTTP $code for /$Command"
     }

--- a/scripts/streamdeck/mutiny-control.ps1
+++ b/scripts/streamdeck/mutiny-control.ps1
@@ -24,7 +24,11 @@ try {
     Write-Host "OK: $($response | ConvertTo-Json -Compress)"
     exit 0
 } catch {
-    $code = $_.Exception.Response?.StatusCode?.value__
+    $code = $null
+    $errorResponse = $_.Exception.Response
+    if ($null -ne $errorResponse -and $null -ne $errorResponse.StatusCode) {
+        $code = $errorResponse.StatusCode.value__
+    }
     if ($null -eq $code) {
         Write-Warning $_.Exception.Message
     } else {

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*?asset" {
+  const assetPath: string;
+  export default assetPath;
+}

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -2,6 +2,7 @@ declare type DesktopConfig = {
   firstLaunch: boolean;
   customFrame: boolean;
   minimiseToTray: boolean;
+  startMinimisedToTray: boolean;
   spellchecker: boolean;
   hardwareAcceleration: boolean;
   discordRpc: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,22 @@ import { updateElectronApp } from "update-electron-app";
 import { BrowserWindow, app, dialog, ipcMain, session, shell, systemPreferences } from "electron";
 import started from "electron-squirrel-startup";
 
-import { autoLaunch } from "./native/autoLaunch";
+import "./native/autoLaunch";
+import { initBadges } from "./native/badges";
 import { config } from "./native/config";
 import { initControlServer } from "./native/controlServer";
 import { initDiscordRpc } from "./native/discordRpc";
 import { showScreenPicker } from "./native/screenPicker";
+import {
+  ProtocolUrlQueue,
+  applyFirstLaunchAutostart,
+  extractProtocolUrls,
+  isLoginItemLaunch,
+  shouldStartMinimised,
+} from "./native/startup";
 import { initTray } from "./native/tray";
 import { BUILD_URL, createMainWindow, mainWindow } from "./native/window";
+import { registerWindowControlHandlers } from "./native/windowControls";
 
 // Squirrel-specific logic
 // create/remove shortcuts on Windows when installing / uninstalling
@@ -24,6 +33,7 @@ if (!config.hardwareAcceleration) {
 }
 
 // ensure only one copy of the application can run
+const protocolUrls = new ProtocolUrlQueue();
 const acquiredLock = app.requestSingleInstanceLock();
 
 if (acquiredLock) {
@@ -36,31 +46,22 @@ if (acquiredLock) {
     app.setAsDefaultProtocolClient('mutiny');
   }
 
-  // Handle protocol URLs on macOS
-  app.on('open-url', (event, url) => {
+  // Queue protocol URLs until the hosted renderer has finished loading.
+  app.on("open-url", (event, url) => {
     event.preventDefault();
-    if (mainWindow) {
+    protocolUrls.enqueue(url);
+    if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.show();
       mainWindow.focus();
-      mainWindow.webContents.send('protocol-url', url);
     }
   });
-
-  // Handle protocol URLs on Windows/Linux
-  const protocolUrl = process.argv.find(arg => arg.startsWith('mutiny://'));
-  if (protocolUrl) {
-    setTimeout(() => {
-      if (mainWindow) {
-        mainWindow.webContents.send('protocol-url', protocolUrl);
-      }
-    }, 1000);
-  }
+  for (const url of extractProtocolUrls(process.argv)) protocolUrls.enqueue(url);
 
   // start auto update logic
   updateElectronApp();
 
   // create and configure the app when electron is ready
-  app.on("ready", () => {
+  app.on("ready", async () => {
     // Set COOP/COEP headers to enable SharedArrayBuffer for AudioWorklet
     // (required by DeepFilterNet3 noise suppression)
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
@@ -135,15 +136,30 @@ if (acquiredLock) {
       systemPreferences.getMediaAccessStatus("screen");
     }
 
-    // enable auto start on Windows and MacOS
-    if (config.firstLaunch) {
-      if (process.platform === "win32" || process.platform === "darwin") {
-        autoLaunch.enable();
-      }
+    // Apply the one-time autostart default before creating the first window.
+    try {
+      applyFirstLaunchAutostart(config);
+    } catch (error) {
+      console.error("[mutiny] Failed to apply the autostart default", error);
     }
 
-    // create window and application contexts
-    createMainWindow();
+    const wasOpenedAtLogin = isLoginItemLaunch(
+      process.platform,
+      process.argv,
+      app.getLoginItemSettings().wasOpenedAtLogin,
+    );
+    const window = createMainWindow({
+      startMinimised: shouldStartMinimised(
+        config.startMinimisedToTray,
+        wasOpenedAtLogin,
+      ),
+    });
+    window.webContents.once("did-finish-load", () =>
+      protocolUrls.rendererReady(window),
+    );
+
+    registerWindowControlHandlers(ipcMain, () => mainWindow);
+    initBadges();
     initTray();
     initDiscordRpc();
     initControlServer();
@@ -154,11 +170,14 @@ if (acquiredLock) {
     }
   });
 
-  // focus the window if we try to launch again
-  app.on("second-instance", () => {
-    mainWindow.show();
-    mainWindow.restore();
-    mainWindow.focus();
+  // Focus the current window and deliver protocol argv from a second process.
+  app.on("second-instance", (_event, argv) => {
+    for (const url of extractProtocolUrls(argv)) protocolUrls.enqueue(url);
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.show();
+      mainWindow.restore();
+      mainWindow.focus();
+    }
   });
 
   // macOS specific behaviour to keep app active in dock:
@@ -172,8 +191,11 @@ if (acquiredLock) {
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      createMainWindow();
-    } else {
+      const window = createMainWindow();
+      window.webContents.once("did-finish-load", () =>
+        protocolUrls.rendererReady(window),
+      );
+    } else if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.show();
       mainWindow.focus();
     }

--- a/src/native/autoLaunch.ts
+++ b/src/native/autoLaunch.ts
@@ -1,23 +1,39 @@
 import AutoLaunch from "auto-launch";
+import { app, ipcMain } from "electron";
 
-import { ipcMain } from "electron";
+import { WINDOWS_AUTOSTART_ARG } from "./startup";
 
-import { mainWindow } from "./window";
+const linuxAutoLaunch = new AutoLaunch({ name: "Mutiny" });
 
-export const autoLaunch = new AutoLaunch({
-  name: "Mutiny",
-});
+export const autoLaunch = {
+  async isEnabled(): Promise<boolean> {
+    if (process.platform === "linux") return linuxAutoLaunch.isEnabled();
+    return app.getLoginItemSettings().openAtLogin;
+  },
 
-ipcMain.on("isAutostart?", () =>
-  autoLaunch
-    .isEnabled()
-    .then((enabled) => mainWindow.webContents.send("isAutostart", enabled)),
-);
+  async enable(): Promise<void> {
+    if (process.platform === "linux") return linuxAutoLaunch.enable();
+    app.setLoginItemSettings({
+      openAtLogin: true,
+      args: process.platform === "win32" ? [WINDOWS_AUTOSTART_ARG] : [],
+    });
+  },
 
-ipcMain.on("setAutostart", (_event, state: boolean) => {
+  async disable(): Promise<void> {
+    if (process.platform === "linux") return linuxAutoLaunch.disable();
+    app.setLoginItemSettings({
+      openAtLogin: false,
+      args: process.platform === "win32" ? [WINDOWS_AUTOSTART_ARG] : [],
+    });
+  },
+};
+
+ipcMain.handle("autostart:get", async (): Promise<boolean> => autoLaunch.isEnabled());
+ipcMain.handle("autostart:set", async (_event, state: boolean): Promise<boolean> => {
   if (state) {
-    autoLaunch.enable();
+    await autoLaunch.enable();
   } else {
-    autoLaunch.disable();
+    await autoLaunch.disable();
   }
+  return autoLaunch.isEnabled();
 });

--- a/src/native/autoLaunch.ts
+++ b/src/native/autoLaunch.ts
@@ -1,30 +1,39 @@
 import AutoLaunch from "auto-launch";
 import { app, ipcMain } from "electron";
 
-import { WINDOWS_AUTOSTART_ARG, linuxAutoLaunchOptions } from "./startup";
+import {
+  disableWindowsAutoLaunch,
+  enableWindowsAutoLaunch,
+  linuxAutoLaunchOptions,
+  reconcileWindowsAutoLaunch,
+} from "./startup";
 
 const linuxAutoLaunch = new AutoLaunch(linuxAutoLaunchOptions());
+const legacyWindowsAutoLaunch = new AutoLaunch({ name: "Mutiny" });
 
 export const autoLaunch = {
   async isEnabled(): Promise<boolean> {
     if (process.platform === "linux") return linuxAutoLaunch.isEnabled();
+    if (process.platform === "win32") {
+      return reconcileWindowsAutoLaunch(app, legacyWindowsAutoLaunch, process.execPath);
+    }
     return app.getLoginItemSettings().openAtLogin;
   },
 
   async enable(): Promise<void> {
     if (process.platform === "linux") return linuxAutoLaunch.enable();
-    app.setLoginItemSettings({
-      openAtLogin: true,
-      args: process.platform === "win32" ? [WINDOWS_AUTOSTART_ARG] : [],
-    });
+    if (process.platform === "win32") {
+      return enableWindowsAutoLaunch(app, legacyWindowsAutoLaunch, process.execPath);
+    }
+    app.setLoginItemSettings({ openAtLogin: true });
   },
 
   async disable(): Promise<void> {
     if (process.platform === "linux") return linuxAutoLaunch.disable();
-    app.setLoginItemSettings({
-      openAtLogin: false,
-      args: process.platform === "win32" ? [WINDOWS_AUTOSTART_ARG] : [],
-    });
+    if (process.platform === "win32") {
+      return disableWindowsAutoLaunch(app, legacyWindowsAutoLaunch, process.execPath);
+    }
+    app.setLoginItemSettings({ openAtLogin: false });
   },
 };
 

--- a/src/native/autoLaunch.ts
+++ b/src/native/autoLaunch.ts
@@ -1,9 +1,9 @@
 import AutoLaunch from "auto-launch";
 import { app, ipcMain } from "electron";
 
-import { WINDOWS_AUTOSTART_ARG } from "./startup";
+import { WINDOWS_AUTOSTART_ARG, linuxAutoLaunchOptions } from "./startup";
 
-const linuxAutoLaunch = new AutoLaunch({ name: "Mutiny" });
+const linuxAutoLaunch = new AutoLaunch(linuxAutoLaunchOptions());
 
 export const autoLaunch = {
   async isEnabled(): Promise<boolean> {

--- a/src/native/badgePolicy.ts
+++ b/src/native/badgePolicy.ts
@@ -1,0 +1,20 @@
+export type BadgePlan =
+  | { kind: "dock"; label: string }
+  | { kind: "app"; count?: number }
+  | { kind: "overlay"; count: number }
+  | { kind: "none" };
+
+export function normalizeBadgeCacheKey(count: number): number {
+  return count === -1 ? -1 : Math.min(count, 10);
+}
+
+export function badgePlan(platform: NodeJS.Platform, count: number): BadgePlan {
+  if (platform === "darwin") {
+    return { kind: "dock", label: count === -1 ? "•" : count === 0 ? "" : String(count) };
+  }
+  if (platform === "linux") {
+    return count === -1 ? { kind: "app" } : { kind: "app", count };
+  }
+  if (platform === "win32") return { kind: "overlay", count };
+  return { kind: "none" };
+}

--- a/src/native/badges.ts
+++ b/src/native/badges.ts
@@ -1,69 +1,41 @@
-import dbus from "@homebridge/dbus-native";
-
 import { NativeImage, app, ipcMain, nativeImage } from "electron";
 
+import { registerBadgeHandler } from "./badgesRegistration";
 import { mainWindow } from "./window";
 
-// internal state
 const nativeIcons: Record<number, NativeImage> = {};
-let sessionBus: dbus.MessageBus | null;
 
-export async function setBadgeCount(count: number) {
-  switch (process.platform) {
-    case "win32":
-    case "linux":
-      if (count === 0) {
-        mainWindow.setOverlayIcon(null, "No Notifications");
-        break;
-      }
+function createBadgeIcon(count: number): NativeImage {
+  const label = count === -1 ? "•" : String(Math.min(count, 10));
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><circle cx="16" cy="16" r="15" fill="#d32f2f"/><text x="16" y="21" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="white">${label}</text></svg>`;
+  return nativeImage.createFromDataURL(
+    `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`,
+  );
+}
 
-      if (!nativeIcons[count])
-        nativeIcons[count] = nativeImage.createFromDataURL(
-          await import(
-            `../../assets/desktop/badges/${Math.min(count, 10)}.ico?asset`
-          ).then((asset) => asset.default),
-        );
+export async function setBadgeCount(count: number): Promise<void> {
+  if (!Number.isInteger(count) || count < -1 || !mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
 
-      mainWindow.setOverlayIcon(
-        nativeIcons[count],
-        count === -1 ? `Unread Messages` : `${count} Notifications`,
-      );
+  if (process.platform === "darwin") {
+    app.dock.setBadge(count === -1 ? "•" : count === 0 ? "" : count.toString());
+    return;
+  }
 
-      break;
-    // @ts-expect-error this is `linux` block
-    case "_": // todo: try to get this to work
-      // send D-Bus message
-      // @ts-expect-error undocumented API
-      if (!sessionBus) sessionBus = dbus.sessionBus();
-
-      // @ts-expect-error undocumented API
-      sessionBus.connection.message({
-        // @ts-expect-error undocumented API
-        type: dbus.messageType.signal,
-        serial: 1,
-        path: "/",
-        interface: "com.canonical.Unity.LauncherEntry",
-        member: "Update",
-        signature: "sa{sv}",
-        body: [
-          process.env.container === "1"
-            ? "application://gg.mutinyapp.mutiny-desktop.desktop" // flatpak handling
-            : "application://mutiny-desktop.desktop",
-          [
-            ["count", ["x", Math.min(count, 0)]],
-            ["count-visible", ["b", count !== 0]],
-          ],
-        ],
-      });
-
-      break;
-    case "darwin":
-      app.dock.setBadge(
-        count === -1 ? "•" : count === 0 ? "" : count.toString(),
-      );
-
-      break;
+  if (process.platform === "win32" || process.platform === "linux") {
+    if (count === 0) {
+      mainWindow.setOverlayIcon(null, "No Notifications");
+      return;
+    }
+    nativeIcons[count] ??= createBadgeIcon(count);
+    mainWindow.setOverlayIcon(
+      nativeIcons[count],
+      count === -1 ? "Unread Messages" : `${count} Notifications`,
+    );
   }
 }
 
-ipcMain.on("setBadgeCount", (_event, count: number) => setBadgeCount(count));
+export function initBadges(): void {
+  registerBadgeHandler(ipcMain, setBadgeCount);
+}

--- a/src/native/badges.ts
+++ b/src/native/badges.ts
@@ -1,6 +1,7 @@
 import { NativeImage, app, ipcMain, nativeImage } from "electron";
 
 import { registerBadgeHandler } from "./badgesRegistration";
+import { badgePlan, normalizeBadgeCacheKey } from "./badgePolicy";
 import { mainWindow } from "./window";
 
 const nativeIcons: Record<number, NativeImage> = {};
@@ -18,20 +19,27 @@ export async function setBadgeCount(count: number): Promise<void> {
     return;
   }
 
-  if (process.platform === "darwin") {
-    app.dock.setBadge(count === -1 ? "•" : count === 0 ? "" : count.toString());
+  const plan = badgePlan(process.platform, count);
+  if (plan.kind === "dock") {
+    app.dock.setBadge(plan.label);
     return;
   }
 
-  if (process.platform === "win32" || process.platform === "linux") {
-    if (count === 0) {
+  if (plan.kind === "app") {
+    app.setBadgeCount(plan.count);
+    return;
+  }
+
+  if (plan.kind === "overlay") {
+    if (plan.count === 0) {
       mainWindow.setOverlayIcon(null, "No Notifications");
       return;
     }
-    nativeIcons[count] ??= createBadgeIcon(count);
+    const cacheKey = normalizeBadgeCacheKey(plan.count);
+    nativeIcons[cacheKey] ??= createBadgeIcon(cacheKey);
     mainWindow.setOverlayIcon(
-      nativeIcons[count],
-      count === -1 ? "Unread Messages" : `${count} Notifications`,
+      nativeIcons[cacheKey],
+      plan.count === -1 ? "Unread Messages" : `${plan.count} Notifications`,
     );
   }
 }

--- a/src/native/badgesRegistration.ts
+++ b/src/native/badgesRegistration.ts
@@ -1,0 +1,19 @@
+type IpcLike = {
+  on(
+    channel: string,
+    listener: (_event: unknown, count: number) => void,
+  ): unknown;
+};
+
+const registered = new WeakSet<object>();
+
+export function registerBadgeHandler(
+  ipc: IpcLike,
+  setBadge: (count: number) => Promise<void> | void,
+): void {
+  if (registered.has(ipc as object)) return;
+  registered.add(ipc as object);
+  ipc.on("setBadgeCount", (_event, count) => {
+    void setBadge(count);
+  });
+}

--- a/src/native/config.ts
+++ b/src/native/config.ts
@@ -1,65 +1,14 @@
-import { type JSONSchema } from "json-schema-typed";
-
 import { ipcMain } from "electron";
 import Store from "electron-store";
+
+import { configDefaults, configSchema } from "./configSchema";
 
 import { destroyDiscordRpc, initDiscordRpc } from "./discordRpc";
 import { mainWindow } from "./window";
 
-const schema = {
-  firstLaunch: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  customFrame: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  minimiseToTray: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  spellchecker: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  hardwareAcceleration: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  discordRpc: {
-    type: "boolean",
-  } as JSONSchema.Boolean,
-  windowState: {
-    type: "object",
-    properties: {
-      // x: {
-      //   type: 'number'
-      // } as JSONSchema.Number,
-      // y: {
-      //   type: 'number'
-      // } as JSONSchema.Number,
-      // width: {
-      //   type: 'number'
-      // } as JSONSchema.Number,
-      // height: {
-      //   type: 'number'
-      // } as JSONSchema.Number,
-      isMaximised: {
-        type: "boolean",
-      } as JSONSchema.Boolean,
-    },
-  } as JSONSchema.Object,
-};
-
 const store = new Store({
-  schema,
-  defaults: {
-    firstLaunch: true,
-    customFrame: true,
-    minimiseToTray: true,
-    spellchecker: true,
-    hardwareAcceleration: true,
-    discordRpc: true,
-    windowState: {
-      isMaximised: false,
-    },
-  } as DesktopConfig,
+  schema: configSchema,
+  defaults: configDefaults,
 });
 
 /**
@@ -67,10 +16,12 @@ const store = new Store({
  */
 class Config {
   sync() {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
     mainWindow.webContents.send("config", {
       firstLaunch: this.firstLaunch,
       customFrame: this.customFrame,
       minimiseToTray: this.minimiseToTray,
+      startMinimisedToTray: this.startMinimisedToTray,
       spellchecker: this.spellchecker,
       hardwareAcceleration: this.hardwareAcceleration,
       discordRpc: this.discordRpc,
@@ -116,6 +67,20 @@ class Config {
       value,
     );
 
+    this.sync();
+  }
+
+  get startMinimisedToTray() {
+    return (store as never as { get(k: string): boolean }).get(
+      "startMinimisedToTray",
+    );
+  }
+
+  set startMinimisedToTray(value: boolean) {
+    (store as never as { set(k: string, value: boolean): void }).set(
+      "startMinimisedToTray",
+      value,
+    );
     this.sync();
   }
 

--- a/src/native/configSchema.ts
+++ b/src/native/configSchema.ts
@@ -1,0 +1,28 @@
+import { type JSONSchema } from "json-schema-typed";
+
+export const configSchema = {
+  firstLaunch: { type: "boolean" } as JSONSchema.Boolean,
+  customFrame: { type: "boolean" } as JSONSchema.Boolean,
+  minimiseToTray: { type: "boolean" } as JSONSchema.Boolean,
+  startMinimisedToTray: { type: "boolean" } as JSONSchema.Boolean,
+  spellchecker: { type: "boolean" } as JSONSchema.Boolean,
+  hardwareAcceleration: { type: "boolean" } as JSONSchema.Boolean,
+  discordRpc: { type: "boolean" } as JSONSchema.Boolean,
+  windowState: {
+    type: "object",
+    properties: {
+      isMaximised: { type: "boolean" } as JSONSchema.Boolean,
+    },
+  } as JSONSchema.Object,
+};
+
+export const configDefaults: DesktopConfig = {
+  firstLaunch: true,
+  customFrame: true,
+  minimiseToTray: true,
+  startMinimisedToTray: false,
+  spellchecker: true,
+  hardwareAcceleration: true,
+  discordRpc: true,
+  windowState: { isMaximised: false },
+};

--- a/src/native/controlPolicy.ts
+++ b/src/native/controlPolicy.ts
@@ -1,0 +1,45 @@
+import { timingSafeEqual } from "node:crypto";
+
+export type ControlRequest = {
+  method?: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+  token: string;
+};
+
+type PolicyResult = { allowed: true } | { allowed: false; status: number; error: string };
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function tokenMatches(actual: string | undefined, expected: string): boolean {
+  if (!actual?.startsWith("Bearer ")) return false;
+  const supplied = Buffer.from(actual.slice(7));
+  const wanted = Buffer.from(expected);
+  return supplied.length === wanted.length && timingSafeEqual(supplied, wanted);
+}
+
+export function authorizeControlRequest(request: ControlRequest): PolicyResult {
+  if (request.path === "/ping") {
+    return request.method === "GET"
+      ? { allowed: true }
+      : { allowed: false, status: 405, error: "Method not allowed" };
+  }
+
+  if (request.method !== "POST") {
+    return { allowed: false, status: 405, error: "State-changing commands require POST" };
+  }
+
+  if (!tokenMatches(headerValue(request.headers.authorization), request.token)) {
+    return { allowed: false, status: 401, error: "Unauthorized" };
+  }
+
+  const origin = headerValue(request.headers.origin);
+  const fetchSite = headerValue(request.headers["sec-fetch-site"]);
+  if (origin || (fetchSite && fetchSite !== "none")) {
+    return { allowed: false, status: 403, error: "Browser-originated commands are forbidden" };
+  }
+
+  return { allowed: true };
+}

--- a/src/native/controlServer.ts
+++ b/src/native/controlServer.ts
@@ -1,104 +1,23 @@
 /**
- * Stream Deck Control Server
- *
- * Tiny HTTP server (127.0.0.1:7423) that accepts commands from Stream Deck
- * PowerShell scripts and forwards them to the Mutiny renderer via executeJavaScript.
- *
- * Endpoints:
- *   GET /ping           — health check, returns "pong"
- *   GET /toggle-mute    — toggle microphone mute
- *   GET /toggle-deafen  — toggle deafen
- *   GET /disconnect     — leave the current voice channel
- *   GET /focus          — bring the Mutiny window to front
- *
- * All endpoints respond with JSON: { ok: true, result: string }
- * Only 127.0.0.1 connections are accepted.
+ * Authenticated loopback control server for local Stream Deck scripts.
+ * GET /ping is read-only. Every state-changing command requires an
+ * origin-less POST with the session bearer token stored in the user-data dir.
  */
+import { randomBytes } from "node:crypto";
+import { chmodSync, writeFileSync } from "node:fs";
+import * as http from "node:http";
+import { join } from "node:path";
 
-import * as http from "http";
+import { app } from "electron";
 
+import { authorizeControlRequest } from "./controlPolicy";
+import { voiceControlScript, type VoiceControlAction } from "./voiceControl";
 import { mainWindow } from "./window";
 
 const PORT = 7423;
 const HOST = "127.0.0.1";
 
-// JS injected into the renderer for each command.
-// Uses multiple selector strategies for resilience across Mutiny frontend versions.
-const SCRIPTS = {
-  toggleMute: `
-    (function () {
-      // Strategy 1: tooltip title (classic Mutiny)
-      const byTitle = document.querySelector(
-        'button[title*="Mute microphone"], button[title*="Unmute microphone"]'
-      );
-      if (byTitle) { byTitle.click(); return 'clicked:title'; }
-
-      // Strategy 2: aria-label
-      const byAria = document.querySelector(
-        'button[aria-label*="ute microphone"]'
-      );
-      if (byAria) { byAria.click(); return 'clicked:aria'; }
-
-      // Strategy 3: data-tooltip (newer Mutiny frontend)
-      const byTooltip = document.querySelector(
-        '[data-tooltip*="ute microphone"]'
-      );
-      if (byTooltip) { byTooltip.click(); return 'clicked:data-tooltip'; }
-
-      // Strategy 4: find the voice panel and click the first non-disconnect button
-      const panel = document.querySelector(
-        '[class*="voice" i] .actions, [class*="VoiceHeader"] .actions, [class*="call-controls"]'
-      );
-      if (panel) {
-        const btns = [...panel.querySelectorAll('button')];
-        // Disconnect button usually has a phone/hangup icon — skip it
-        const micBtn = btns.find(b => !b.querySelector('[class*="phone" i], [class*="hangup" i]'));
-        if (micBtn) { micBtn.click(); return 'clicked:panel-button'; }
-      }
-
-      return 'not-found';
-    })()
-  `,
-
-  toggleDeafen: `
-    (function () {
-      const byTitle = document.querySelector(
-        'button[title*="Deafen"], button[title*="Undeafen"]'
-      );
-      if (byTitle) { byTitle.click(); return 'clicked:title'; }
-
-      const byAria = document.querySelector(
-        'button[aria-label*="eafen"]'
-      );
-      if (byAria) { byAria.click(); return 'clicked:aria'; }
-
-      const byTooltip = document.querySelector('[data-tooltip*="eafen"]');
-      if (byTooltip) { byTooltip.click(); return 'clicked:data-tooltip'; }
-
-      return 'not-found';
-    })()
-  `,
-
-  disconnect: `
-    (function () {
-      const byTitle = document.querySelector(
-        'button[title*="Disconnect"], button[title*="Leave"], button[title*="Hang up"]'
-      );
-      if (byTitle) { byTitle.click(); return 'clicked:title'; }
-
-      const byAria = document.querySelector(
-        'button[aria-label*="isconnect"], button[aria-label*="eave"]'
-      );
-      if (byAria) { byAria.click(); return 'clicked:aria'; }
-
-      return 'not-found';
-    })()
-  `,
-} as const;
-
-type CommandKey = keyof typeof SCRIPTS;
-
-const ROUTES: Record<string, CommandKey | "focus" | "ping"> = {
+const ROUTES: Record<string, VoiceControlAction | "focus" | "ping"> = {
   "/toggle-mute": "toggleMute",
   "/mute": "toggleMute",
   "/toggle-deafen": "toggleDeafen",
@@ -109,74 +28,94 @@ const ROUTES: Record<string, CommandKey | "focus" | "ping"> = {
   "/ping": "ping",
 };
 
-export function initControlServer(): void {
-  const server = http.createServer(async (req, res) => {
-    // Reject non-local connections
+function respond(res: http.ServerResponse, status: number, body: object): void {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+  });
+  res.end(JSON.stringify(body));
+}
+
+export function createControlServer(token: string): http.Server {
+  return http.createServer(async (req, res) => {
     const remote = req.socket.remoteAddress ?? "";
     if (!["127.0.0.1", "::1", "::ffff:127.0.0.1"].includes(remote)) {
-      res.writeHead(403, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Forbidden" }));
+      respond(res, 403, { ok: false, error: "Forbidden" });
       return;
     }
 
     const path = (req.url ?? "/").split("?")[0];
     const action = ROUTES[path];
-
     if (!action) {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: "Unknown command",
-          path,
-          available: Object.keys(ROUTES),
-        }),
-      );
+      respond(res, 404, { ok: false, error: "Unknown command" });
+      return;
+    }
+
+    const policy = authorizeControlRequest({
+      method: req.method,
+      path,
+      headers: req.headers,
+      token,
+    });
+    if (policy.allowed === false) {
+      respond(res, policy.status, { ok: false, error: policy.error });
+      return;
+    }
+
+    if (action === "ping") {
+      respond(res, 200, { ok: true, result: "pong" });
       return;
     }
 
     if (!mainWindow || mainWindow.isDestroyed()) {
-      res.writeHead(503, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Mutiny window not available" }));
+      respond(res, 503, { ok: false, error: "Mutiny window not available" });
       return;
     }
 
     try {
       let result: string;
-
-      if (action === "ping") {
-        result = "pong";
-      } else if (action === "focus") {
+      if (action === "focus") {
         mainWindow.show();
         mainWindow.focus();
         result = "focused";
       } else {
         result = await mainWindow.webContents.executeJavaScript(
-          SCRIPTS[action],
+          voiceControlScript(action),
         );
       }
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, result }));
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: message }));
+      if (result === "not-found") {
+        respond(res, 409, { ok: false, result });
+        return;
+      }
+      respond(res, 200, { ok: true, result });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(res, 500, { ok: false, error: message });
     }
   });
+}
 
+export function initControlServer(): void {
+  const token = randomBytes(32).toString("hex");
+  const tokenPath = join(app.getPath("userData"), "streamdeck-token");
+  try {
+    writeFileSync(tokenPath, token, { encoding: "utf8", mode: 0o600 });
+    if (process.platform !== "win32") chmodSync(tokenPath, 0o600);
+  } catch (error) {
+    console.error("[mutiny] Control server token provisioning failed; server disabled", error);
+    return;
+  }
+
+  const server = createControlServer(token);
   server.listen(PORT, HOST, () => {
-    console.log(
-      `[mutiny] Stream Deck control server → http://${HOST}:${PORT}`,
-    );
+    console.log(`[mutiny] Stream Deck control server listening on ${HOST}:${PORT}`);
   });
-
-  server.on("error", (err: NodeJS.ErrnoException) => {
-    if (err.code === "EADDRINUSE") {
-      console.warn(
-        `[mutiny] Control server: port ${PORT} already in use — skipping`,
-      );
+  server.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EADDRINUSE") {
+      console.warn(`[mutiny] Control server: port ${PORT} already in use — skipping`);
     } else {
-      console.error("[mutiny] Control server error:", err);
+      console.error("[mutiny] Control server error:", error);
     }
   });
 }

--- a/src/native/screenPicker.ts
+++ b/src/native/screenPicker.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, desktopCapturer, ipcMain } from "electron";
+import { BrowserWindow, desktopCapturer } from "electron";
 import { mainWindow } from "./window";
 
 /**

--- a/src/native/startup.ts
+++ b/src/native/startup.ts
@@ -1,5 +1,80 @@
+import { win32 } from "node:path";
+
 export type StartupConfig = { firstLaunch: boolean };
 export const WINDOWS_AUTOSTART_ARG = "--mutiny-autostart";
+
+export type WindowsLoginItemSettings = {
+  openAtLogin: boolean;
+  path: string;
+  args: string[];
+};
+
+type WindowsLoginItemApp = {
+  getLoginItemSettings?: (settings: { path: string; args: string[] }) => {
+    openAtLogin: boolean;
+  };
+  setLoginItemSettings(settings: WindowsLoginItemSettings): void;
+};
+
+type LegacyAutoLaunch = {
+  isEnabled(): Promise<boolean>;
+  disable(): Promise<unknown>;
+};
+
+function windowsAutoLaunchIdentity(execPath: string): { path: string; args: string[] } {
+  const executableName = win32.basename(execPath);
+  return {
+    path: win32.join(win32.dirname(execPath), "..", "Update.exe"),
+    args: [
+      "--processStart",
+      `"${executableName}"`,
+      "--process-start-args",
+      `"${WINDOWS_AUTOSTART_ARG}"`,
+    ],
+  };
+}
+
+export function windowsAutoLaunchSettings(
+  execPath: string,
+  openAtLogin: boolean,
+): WindowsLoginItemSettings {
+  return { openAtLogin, ...windowsAutoLaunchIdentity(execPath) };
+}
+
+export async function enableWindowsAutoLaunch(
+  app: WindowsLoginItemApp,
+  legacy: LegacyAutoLaunch,
+  execPath: string,
+): Promise<void> {
+  await legacy.disable();
+  app.setLoginItemSettings(windowsAutoLaunchSettings(execPath, true));
+}
+
+export async function disableWindowsAutoLaunch(
+  app: WindowsLoginItemApp,
+  legacy: LegacyAutoLaunch,
+  execPath: string,
+): Promise<void> {
+  app.setLoginItemSettings(windowsAutoLaunchSettings(execPath, false));
+  await legacy.disable();
+}
+
+export async function reconcileWindowsAutoLaunch(
+  app: WindowsLoginItemApp,
+  legacy: LegacyAutoLaunch,
+  execPath: string,
+): Promise<boolean> {
+  if (!app.getLoginItemSettings) return false;
+
+  const stableEnabled = app.getLoginItemSettings(
+    windowsAutoLaunchIdentity(execPath),
+  ).openAtLogin;
+  if (stableEnabled) return true;
+  if (!(await legacy.isEnabled())) return false;
+
+  await enableWindowsAutoLaunch(app, legacy, execPath);
+  return true;
+}
 // auto-launch's supported Linux Desktop Entry mechanism appends this argument
 // when `isHidden` is enabled. It also gives us an unambiguous login launch signal.
 export const LINUX_AUTOSTART_ARG = "--hidden";

--- a/src/native/startup.ts
+++ b/src/native/startup.ts
@@ -1,0 +1,74 @@
+export type StartupConfig = { firstLaunch: boolean };
+export const WINDOWS_AUTOSTART_ARG = "--mutiny-autostart";
+
+export function applyFirstLaunchAutostart(
+  config: StartupConfig,
+): void {
+  if (!config.firstLaunch) return;
+
+  // Previous releases left this flag set for existing installations, including
+  // users who had explicitly disabled autostart. Never turn a login item back
+  // on implicitly during migration; autostart is controlled only by the user's
+  // explicit setting from this point forward.
+  config.firstLaunch = false;
+}
+
+export function isLoginItemLaunch(
+  platform: NodeJS.Platform,
+  argv: string[],
+  wasOpenedAtLogin: boolean,
+): boolean {
+  if (platform === "win32") return argv.includes(WINDOWS_AUTOSTART_ARG);
+  if (platform === "darwin") return wasOpenedAtLogin;
+  return false;
+}
+
+export function shouldStartMinimised(
+  startMinimisedToTray: boolean,
+  wasOpenedAtLogin: boolean,
+): boolean {
+  return startMinimisedToTray && wasOpenedAtLogin;
+}
+
+export function shouldRestoreMaximised(
+  wasMaximised: boolean,
+  startMinimised: boolean,
+): boolean {
+  return wasMaximised && !startMinimised;
+}
+
+export function extractProtocolUrls(argv: string[]): string[] {
+  return argv.filter((arg) => {
+    try {
+      return new URL(arg).protocol === "mutiny:";
+    } catch {
+      return false;
+    }
+  });
+}
+
+type ProtocolWindow = {
+  isDestroyed?: () => boolean;
+  webContents: { send(channel: string, url: string): void };
+};
+
+export class ProtocolUrlQueue {
+  private pending: string[] = [];
+  private target?: ProtocolWindow;
+
+  enqueue(url: string): void {
+    if (!extractProtocolUrls([url]).length) return;
+    if (this.target && !this.target.isDestroyed?.()) {
+      this.target.webContents.send("protocol-url", url);
+      return;
+    }
+    this.pending.push(url);
+  }
+
+  rendererReady(target: ProtocolWindow): void {
+    this.target = target;
+    for (const url of this.pending.splice(0)) {
+      target.webContents.send("protocol-url", url);
+    }
+  }
+}

--- a/src/native/startup.ts
+++ b/src/native/startup.ts
@@ -1,5 +1,12 @@
 export type StartupConfig = { firstLaunch: boolean };
 export const WINDOWS_AUTOSTART_ARG = "--mutiny-autostart";
+// auto-launch's supported Linux Desktop Entry mechanism appends this argument
+// when `isHidden` is enabled. It also gives us an unambiguous login launch signal.
+export const LINUX_AUTOSTART_ARG = "--hidden";
+
+export function linuxAutoLaunchOptions(): { name: string; isHidden: true } {
+  return { name: "Mutiny", isHidden: true };
+}
 
 export function applyFirstLaunchAutostart(
   config: StartupConfig,
@@ -20,6 +27,7 @@ export function isLoginItemLaunch(
 ): boolean {
   if (platform === "win32") return argv.includes(WINDOWS_AUTOSTART_ARG);
   if (platform === "darwin") return wasOpenedAtLogin;
+  if (platform === "linux") return argv.includes(LINUX_AUTOSTART_ARG);
   return false;
 }
 

--- a/src/native/voiceControl.ts
+++ b/src/native/voiceControl.ts
@@ -1,0 +1,47 @@
+export type VoiceControlAction = "toggleMute" | "toggleDeafen" | "disconnect";
+
+type ButtonLike = {
+  textContent: string | null;
+  disabled?: boolean;
+  click(): void;
+};
+
+type RootLike = {
+  querySelector?(selector: string): ButtonLike | null;
+  querySelectorAll(selector: string): Iterable<ButtonLike>;
+};
+
+export function executeVoiceControl(root: RootLike, action: VoiceControlAction): string {
+  const accessibleSelectors: Record<VoiceControlAction, string> = {
+    toggleMute:
+      'button[title*="Mute microphone"], button[title*="Unmute microphone"], button[aria-label*="ute microphone"], [data-tooltip*="ute microphone"]',
+    toggleDeafen:
+      'button[title*="Deafen"], button[title*="Undeafen"], button[aria-label*="eafen"], [data-tooltip*="eafen"]',
+    disconnect:
+      'button[title*="Disconnect"], button[title*="Leave"], button[title*="Hang up"], button[aria-label*="isconnect"], button[aria-label*="eave"]',
+  };
+  const accessibleControl = root.querySelector?.(accessibleSelectors[action]);
+  if (accessibleControl && !accessibleControl.disabled) {
+    accessibleControl.click();
+    return "clicked:accessible-label";
+  }
+
+  const symbols: Record<VoiceControlAction, string[]> = {
+    toggleMute: ["mic", "mic_off"],
+    toggleDeafen: ["headset", "headset_off"],
+    disconnect: ["call_end"],
+  };
+
+  for (const button of root.querySelectorAll("button")) {
+    const symbol = button.textContent?.trim() ?? "";
+    if (!button.disabled && symbols[action].includes(symbol)) {
+      button.click();
+      return `clicked:${symbol}`;
+    }
+  }
+  return "not-found";
+}
+
+export function voiceControlScript(action: VoiceControlAction): string {
+  return `(${executeVoiceControl.toString()})(document, ${JSON.stringify(action)})`;
+}

--- a/src/native/voiceControl.ts
+++ b/src/native/voiceControl.ts
@@ -12,6 +12,14 @@ type RootLike = {
 };
 
 export function executeVoiceControl(root: RootLike, action: VoiceControlAction): string {
+  const explicitControl = root.querySelector?.(
+    `[data-mutiny-voice-control="${action}"]`,
+  );
+  if (explicitControl && !explicitControl.disabled) {
+    explicitControl.click();
+    return "clicked:explicit-hook";
+  }
+
   const accessibleSelectors: Record<VoiceControlAction, string> = {
     toggleMute:
       'button[title*="Mute microphone"], button[title*="Unmute microphone"], button[aria-label*="ute microphone"], [data-tooltip*="ute microphone"]',

--- a/src/native/window.ts
+++ b/src/native/window.ts
@@ -5,13 +5,13 @@ import {
   Menu,
   MenuItem,
   app,
-  ipcMain,
   nativeImage,
 } from "electron";
 
 import windowIconAsset from "../../assets/desktop/icon.png?asset";
 
 import { config } from "./config";
+import { shouldRestoreMaximised } from "./startup";
 import { updateTrayMenu } from "./tray";
 
 // global reference to main window
@@ -35,9 +35,10 @@ const windowIcon = nativeImage.createFromDataURL(windowIconAsset);
 /**
  * Create the main application window
  */
-export function createMainWindow() {
+export function createMainWindow(options: { startMinimised?: boolean } = {}) {
   // create the window
   mainWindow = new BrowserWindow({
+    show: !options.startMinimised,
     minWidth: 300,
     minHeight: 300,
     width: 1280,
@@ -50,28 +51,34 @@ export function createMainWindow() {
       preload: join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
-      spellcheck: true,
+      spellcheck: config.spellchecker,
     },
   });
 
   // hide the options
   mainWindow.setMenu(null);
 
-  // maximise the window if it was maximised before
-  if (config.windowState.isMaximised) {
+  // Restore visible windows to their previous state. Calling maximize() on a
+  // hidden BrowserWindow makes it visible, defeating login-to-tray startup.
+  if (
+    shouldRestoreMaximised(
+      config.windowState.isMaximised,
+      options.startMinimised === true,
+    )
+  ) {
     mainWindow.maximize();
   }
 
   // load the entrypoint
   mainWindow.loadURL(BUILD_URL.toString());
 
-  mainWindow.webContents.on("did-fail-load", (_e: any, code: number, desc: string, url: string) => {
-    console.error(`[LOAD FAIL] ${url} — ${code}: ${desc}`);
+  mainWindow.webContents.on("did-fail-load", (_event, code, description, url) => {
+    console.error(`[LOAD FAIL] ${url} — ${code}: ${description}`);
   });
   mainWindow.webContents.on("did-finish-load", () => {
     console.log("[LOAD OK] Page finished loading");
   });
-  mainWindow.webContents.on("console-message", (_e: any, _level: number, message: string) => {
+  mainWindow.webContents.on("console-message", (_event, _level, message) => {
     console.log(`[RENDERER] ${message}`);
   });
 
@@ -160,17 +167,8 @@ export function createMainWindow() {
     }
   });
 
-  // push world events to the window
-  ipcMain.on("minimise", () => mainWindow.minimize());
-  ipcMain.on("maximise", () =>
-    mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize(),
-  );
-  ipcMain.on("close", () => mainWindow.close());
-
   // mainWindow.webContents.openDevTools();
-
-  // let i = 0;
-  // setInterval(() => setBadgeCount((++i % 30) + 1), 1000);
+  return mainWindow;
 }
 
 /**

--- a/src/native/windowControls.ts
+++ b/src/native/windowControls.ts
@@ -1,0 +1,31 @@
+type WindowLike = {
+  isDestroyed(): boolean;
+  minimize(): void;
+  close(): void;
+  isMaximized(): boolean;
+  maximize(): void;
+  unmaximize(): void;
+};
+
+type IpcLike = { on(channel: string, listener: () => void): unknown };
+
+const registered = new WeakSet<object>();
+
+export function registerWindowControlHandlers(
+  ipc: IpcLike,
+  getWindow: () => WindowLike | undefined,
+): void {
+  if (registered.has(ipc as object)) return;
+  registered.add(ipc as object);
+
+  const withWindow = (action: (window: WindowLike) => void) => () => {
+    const window = getWindow();
+    if (window && !window.isDestroyed()) action(window);
+  };
+
+  ipc.on("minimise", withWindow((window) => window.minimize()));
+  ipc.on("maximise", withWindow((window) =>
+    window.isMaximized() ? window.unmaximize() : window.maximize(),
+  ));
+  ipc.on("close", withWindow((window) => window.close()));
+}

--- a/src/world/config.ts
+++ b/src/world/config.ts
@@ -2,16 +2,12 @@ import { contextBridge, ipcRenderer } from "electron";
 
 let config: DesktopConfig;
 
-ipcRenderer.on("config", (_, data) => (config = data));
+ipcRenderer.on("config", (_, data: DesktopConfig) => (config = data));
 
 contextBridge.exposeInMainWorld("desktopConfig", {
   get: () => config,
-  set: (config: DesktopConfig) => ipcRenderer.send("config", config),
-  getAutostart() {
-    ipcRenderer.send("isAutostart?");
-    return new Promise((resolve) => ipcRenderer.once("isAutostart", resolve));
-  },
-  setAutostart(value: boolean) {
-    ipcRenderer.send("setAutostart", value);
-  },
+  set: (newConfig: Partial<DesktopConfig>) => ipcRenderer.send("config", newConfig),
+  getAutostart: (): Promise<boolean> => ipcRenderer.invoke("autostart:get"),
+  setAutostart: (value: boolean): Promise<boolean> =>
+    ipcRenderer.invoke("autostart:set", value),
 });

--- a/src/world/window.ts
+++ b/src/world/window.ts
@@ -2,6 +2,12 @@ import { contextBridge, ipcRenderer } from "electron";
 
 import { version } from "../../package.json";
 
+ipcRenderer.on("protocol-url", (_event, url: string) => {
+  window.dispatchEvent(
+    new CustomEvent("mutiny-protocol-url", { detail: url }),
+  );
+});
+
 contextBridge.exposeInMainWorld("native", {
   versions: {
     node: () => process.versions.node,
@@ -18,6 +24,12 @@ contextBridge.exposeInMainWorld("native", {
   close: () => ipcRenderer.send("close"),
 
   setBadgeCount: (count: number) => ipcRenderer.send("setBadgeCount", count),
+
+  onProtocolUrl: (callback: (url: string) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, url: string) => callback(url);
+    ipcRenderer.on("protocol-url", listener);
+    return () => ipcRenderer.removeListener("protocol-url", listener);
+  },
 
   openAudioFile: () => ipcRenderer.invoke("dialog:openAudioFile"),
 });

--- a/tests/badgePolicy.test.ts
+++ b/tests/badgePolicy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { badgePlan, normalizeBadgeCacheKey } from "../src/native/badgePolicy";
+
+describe("badge platform policy", () => {
+  it("uses Electron's supported application badge on Linux", () => {
+    expect(badgePlan("linux", 12)).toEqual({ kind: "app", count: 12 });
+    expect(badgePlan("linux", 0)).toEqual({ kind: "app", count: 0 });
+  });
+
+  it("reserves window overlay icons for Windows", () => {
+    expect(badgePlan("win32", 12)).toEqual({ kind: "overlay", count: 12 });
+  });
+
+  it("normalizes visually equivalent counts to bounded icon cache keys", () => {
+    expect(normalizeBadgeCacheKey(-1)).toBe(-1);
+    expect(normalizeBadgeCacheKey(1)).toBe(1);
+    expect(normalizeBadgeCacheKey(10)).toBe(10);
+    expect(normalizeBadgeCacheKey(11)).toBe(10);
+    expect(normalizeBadgeCacheKey(Number.MAX_SAFE_INTEGER)).toBe(10);
+  });
+});

--- a/tests/badges.test.ts
+++ b/tests/badges.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerBadgeHandler } from "../src/native/badgesRegistration";
+
+class FakeIpc {
+  listeners = new Map<string, Array<(_event: unknown, count: number) => void>>();
+  on(name: string, listener: (_event: unknown, count: number) => void) {
+    this.listeners.set(name, [...(this.listeners.get(name) ?? []), listener]);
+  }
+}
+
+describe("badge IPC", () => {
+  it("loads exactly one handler that forwards nonzero and clear counts", async () => {
+    const ipc = new FakeIpc();
+    const setBadge = vi.fn().mockResolvedValue(undefined);
+    registerBadgeHandler(ipc, setBadge);
+    registerBadgeHandler(ipc, setBadge);
+    expect(ipc.listeners.get("setBadgeCount")).toHaveLength(1);
+
+    const [listener] = ipc.listeners.get("setBadgeCount") ?? [];
+    expect(listener).toBeDefined();
+    if (!listener) throw new Error("badge listener was not registered");
+    listener(undefined, 3);
+    listener(undefined, 0);
+    await Promise.resolve();
+    expect(setBadge).toHaveBeenNthCalledWith(1, 3);
+    expect(setBadge).toHaveBeenNthCalledWith(2, 0);
+  });
+});

--- a/tests/buildWorkflow.test.ts
+++ b/tests/buildWorkflow.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("deprecated Electron build workflow", () => {
+  it("runs validation for relevant pull requests while keeping manual dispatch", () => {
+    const workflow = readFileSync(".github/workflows/build.yml", "utf8");
+    expect(workflow).toMatch(/workflow_dispatch:/);
+    expect(workflow).toMatch(/pull_request:/);
+    expect(workflow).toMatch(/paths:/);
+    expect(workflow).toContain('"src/**"');
+    expect(workflow).toContain('"tests/**"');
+  });
+});

--- a/tests/configSchema.test.ts
+++ b/tests/configSchema.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { configDefaults, configSchema } from "../src/native/configSchema";
+
+describe("desktop config contract", () => {
+  it("persists the hosted startMinimisedToTray key", () => {
+    expect(configSchema.startMinimisedToTray.type).toBe("boolean");
+    expect(configDefaults.startMinimisedToTray).toBe(false);
+  });
+});

--- a/tests/controlPolicy.test.ts
+++ b/tests/controlPolicy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { authorizeControlRequest } from "../src/native/controlPolicy";
+
+const token = "test-token";
+
+describe("Stream Deck request policy", () => {
+  it("keeps ping as a read-only unauthenticated GET", () => {
+    expect(authorizeControlRequest({ method: "GET", path: "/ping", headers: {}, token })).toEqual({ allowed: true });
+  });
+
+  it("rejects state-changing GET requests", () => {
+    expect(authorizeControlRequest({ method: "GET", path: "/disconnect", headers: {}, token })).toMatchObject({ allowed: false, status: 405 });
+  });
+
+  it("rejects unauthenticated mutation requests", () => {
+    expect(authorizeControlRequest({ method: "POST", path: "/toggle-mute", headers: {}, token })).toMatchObject({ allowed: false, status: 401 });
+  });
+
+  it("rejects browser cross-origin mutation even with a token", () => {
+    expect(authorizeControlRequest({
+      method: "POST",
+      path: "/toggle-mute",
+      headers: { authorization: `Bearer ${token}`, origin: "https://evil.example", "sec-fetch-site": "cross-site" },
+      token,
+    })).toMatchObject({ allowed: false, status: 403 });
+  });
+
+  it("allows authenticated local non-browser POST requests", () => {
+    expect(authorizeControlRequest({
+      method: "POST",
+      path: "/toggle-mute",
+      headers: { authorization: `Bearer ${token}` },
+      token,
+    })).toEqual({ allowed: true });
+  });
+});

--- a/tests/controlServer.test.ts
+++ b/tests/controlServer.test.ts
@@ -1,0 +1,70 @@
+import type { AddressInfo } from "node:net";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp" },
+}));
+vi.mock("../src/native/window", () => ({ mainWindow: undefined }));
+
+import { createControlServer } from "../src/native/controlServer";
+
+const token = "test-token";
+let server: ReturnType<typeof createControlServer>;
+let baseUrl: string;
+
+beforeEach(async () => {
+  server = createControlServer(token);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+});
+
+describe("Stream Deck HTTP server", () => {
+  it("keeps ping unauthenticated and side-effect free", async () => {
+    const response = await fetch(`${baseUrl}/ping`);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, result: "pong" });
+  });
+
+  it("rejects drive-by state-changing GET requests", async () => {
+    const response = await fetch(`${baseUrl}/disconnect`);
+    expect(response.status).toBe(405);
+    await expect(response.json()).resolves.toMatchObject({ ok: false });
+  });
+
+  it("rejects unauthenticated state-changing POST requests", async () => {
+    const response = await fetch(`${baseUrl}/toggle-mute`, { method: "POST" });
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects browser-originated POST requests even with the token", async () => {
+    const response = await fetch(`${baseUrl}/toggle-mute`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Origin: "https://evil.example",
+        "Sec-Fetch-Site": "cross-site",
+      },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("accepts an authenticated origin-less local client request", async () => {
+    const response = await fetch(`${baseUrl}/toggle-mute`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    // The policy accepted the request; no mocked application window is available.
+    expect(response.status).toBe(503);
+  });
+});

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ProtocolUrlQueue,
+  applyFirstLaunchAutostart,
+  extractProtocolUrls,
+  isLoginItemLaunch,
+  shouldRestoreMaximised,
+  shouldStartMinimised,
+} from "../src/native/startup";
+
+describe("startup settings", () => {
+  it("migrates the legacy first-launch flag without enabling autostart", () => {
+    const state = { firstLaunch: true };
+    applyFirstLaunchAutostart(state);
+    expect(state.firstLaunch).toBe(false);
+  });
+
+  it("leaves an already-migrated preference untouched", () => {
+    const state = { firstLaunch: false };
+    applyFirstLaunchAutostart(state);
+    expect(state.firstLaunch).toBe(false);
+  });
+
+  it("uses supported platform signals for login-item launches", () => {
+    expect(isLoginItemLaunch("win32", ["Mutiny.exe", "--mutiny-autostart"], false)).toBe(true);
+    expect(isLoginItemLaunch("win32", ["Mutiny.exe"], true)).toBe(false);
+    expect(isLoginItemLaunch("darwin", ["Mutiny"], true)).toBe(true);
+    expect(isLoginItemLaunch("linux", ["mutiny", "--mutiny-autostart"], true)).toBe(false);
+  });
+
+  it("starts hidden only for a login-item launch with the setting enabled", () => {
+    expect(shouldStartMinimised(true, true)).toBe(true);
+    expect(shouldStartMinimised(true, false)).toBe(false);
+    expect(shouldStartMinimised(false, true)).toBe(false);
+  });
+
+  it("does not reveal a hidden login launch while restoring window state", () => {
+    expect(shouldRestoreMaximised(true, true)).toBe(false);
+    expect(shouldRestoreMaximised(true, false)).toBe(true);
+  });
+});
+
+describe("protocol URLs", () => {
+  it("extracts only valid mutiny URLs from argv", () => {
+    expect(
+      extractProtocolUrls(["Mutiny", "--flag", "mutiny://invite/abc", "https://example.com"]),
+    ).toEqual(["mutiny://invite/abc"]);
+  });
+
+  it("queues cold-launch URLs and flushes once the renderer is ready", () => {
+    const send = vi.fn();
+    const queue = new ProtocolUrlQueue();
+    queue.enqueue("mutiny://invite/cold");
+    expect(send).not.toHaveBeenCalled();
+
+    queue.rendererReady({ webContents: { send } });
+    expect(send).toHaveBeenCalledWith("protocol-url", "mutiny://invite/cold");
+  });
+
+  it("delivers already-running URLs immediately after renderer readiness", () => {
+    const send = vi.fn();
+    const queue = new ProtocolUrlQueue();
+    queue.rendererReady({ webContents: { send } });
+    queue.enqueue("mutiny://channel/running");
+    expect(send).toHaveBeenCalledWith("protocol-url", "mutiny://channel/running");
+  });
+});

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   ProtocolUrlQueue,
+  LINUX_AUTOSTART_ARG,
   applyFirstLaunchAutostart,
   extractProtocolUrls,
   isLoginItemLaunch,
+  linuxAutoLaunchOptions,
   shouldRestoreMaximised,
   shouldStartMinimised,
 } from "../src/native/startup";
@@ -26,7 +28,12 @@ describe("startup settings", () => {
     expect(isLoginItemLaunch("win32", ["Mutiny.exe", "--mutiny-autostart"], false)).toBe(true);
     expect(isLoginItemLaunch("win32", ["Mutiny.exe"], true)).toBe(false);
     expect(isLoginItemLaunch("darwin", ["Mutiny"], true)).toBe(true);
-    expect(isLoginItemLaunch("linux", ["mutiny", "--mutiny-autostart"], true)).toBe(false);
+    expect(isLoginItemLaunch("linux", ["mutiny", LINUX_AUTOSTART_ARG], false)).toBe(true);
+    expect(isLoginItemLaunch("linux", ["mutiny"], true)).toBe(false);
+  });
+
+  it("configures Linux autostart to include its identifiable login argument", () => {
+    expect(linuxAutoLaunchOptions()).toEqual({ name: "Mutiny", isHidden: true });
   });
 
   it("starts hidden only for a login-item launch with the setting enabled", () => {

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -4,11 +4,15 @@ import {
   ProtocolUrlQueue,
   LINUX_AUTOSTART_ARG,
   applyFirstLaunchAutostart,
+  disableWindowsAutoLaunch,
+  enableWindowsAutoLaunch,
   extractProtocolUrls,
   isLoginItemLaunch,
   linuxAutoLaunchOptions,
+  reconcileWindowsAutoLaunch,
   shouldRestoreMaximised,
   shouldStartMinimised,
+  windowsAutoLaunchSettings,
 } from "../src/native/startup";
 
 describe("startup settings", () => {
@@ -34,6 +38,57 @@ describe("startup settings", () => {
 
   it("configures Linux autostart to include its identifiable login argument", () => {
     expect(linuxAutoLaunchOptions()).toEqual({ name: "Mutiny", isHidden: true });
+  });
+
+  it("registers Windows autostart through Squirrel's stable Update.exe", async () => {
+    const execPath = String.raw`C:\Users\test\AppData\Local\Mutiny\app-1.2.2\mutiny-desktop.exe`;
+    const setLoginItemSettings = vi.fn();
+    const legacy = { isEnabled: vi.fn(), enable: vi.fn(), disable: vi.fn() };
+
+    await enableWindowsAutoLaunch({ setLoginItemSettings }, legacy, execPath);
+
+    expect(setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+      path: String.raw`C:\Users\test\AppData\Local\Mutiny\Update.exe`,
+      args: [
+        "--processStart",
+        '"mutiny-desktop.exe"',
+        "--process-start-args",
+        '"--mutiny-autostart"',
+      ],
+    });
+    expect(legacy.disable).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles an enabled legacy Windows entry into the stable Squirrel entry", async () => {
+    const execPath = String.raw`C:\Users\test\AppData\Local\Mutiny\app-1.2.2\mutiny-desktop.exe`;
+    const stableSettings = windowsAutoLaunchSettings(execPath, true);
+    const app = {
+      getLoginItemSettings: vi.fn().mockReturnValue({ openAtLogin: false }),
+      setLoginItemSettings: vi.fn(),
+    };
+    const legacy = {
+      isEnabled: vi.fn().mockResolvedValue(true),
+      enable: vi.fn(),
+      disable: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(reconcileWindowsAutoLaunch(app, legacy, execPath)).resolves.toBe(true);
+    expect(legacy.disable).toHaveBeenCalledOnce();
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith(stableSettings);
+  });
+
+  it("disables both stable and legacy Windows autostart entries", async () => {
+    const execPath = String.raw`C:\Users\test\AppData\Local\Mutiny\app-1.2.2\mutiny-desktop.exe`;
+    const app = { setLoginItemSettings: vi.fn() };
+    const legacy = { isEnabled: vi.fn(), enable: vi.fn(), disable: vi.fn() };
+
+    await disableWindowsAutoLaunch(app, legacy, execPath);
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith(
+      windowsAutoLaunchSettings(execPath, false),
+    );
+    expect(legacy.disable).toHaveBeenCalledOnce();
   });
 
   it("starts hidden only for a login-item launch with the setting enabled", () => {

--- a/tests/streamdeckScript.test.ts
+++ b/tests/streamdeckScript.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const script = readFileSync("scripts/streamdeck/mutiny-control.ps1", "utf8");
+
+describe("Stream Deck PowerShell helper", () => {
+  it("avoids syntax introduced after Windows PowerShell 5.1", () => {
+    const powerShell7OnlyOperators = ["?.", "??", "??=", "&&", "||"];
+
+    for (const operator of powerShell7OnlyOperators) {
+      expect(script, `PowerShell 7-only operator: ${operator}`).not.toContain(operator);
+    }
+  });
+
+  it("preserves HTTP status extraction for error responses", () => {
+    expect(script).toContain("$_.Exception.Response");
+    expect(script).toContain(".StatusCode");
+    expect(script).toContain(".value__");
+    expect(script).toContain('Write-Warning "Mutiny returned HTTP $code for /$Command"');
+  });
+});

--- a/tests/voiceControl.test.ts
+++ b/tests/voiceControl.test.ts
@@ -11,6 +11,24 @@ function root(...buttons: ReturnType<typeof button>[]) {
 }
 
 describe("voice control contract", () => {
+  it("prefers an explicit Mutiny voice-control hook", () => {
+    const explicit = button("custom-icon");
+    const generic = button("mic");
+    const explicitRoot = {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-mutiny-voice-control="toggleMute"]' ? explicit : null,
+      ),
+      querySelectorAll: vi.fn(() => [generic]),
+    };
+
+    expect(executeVoiceControl(explicitRoot, "toggleMute")).toBe("clicked:explicit-hook");
+    expect(explicit.click).toHaveBeenCalledOnce();
+    expect(generic.click).not.toHaveBeenCalled();
+    expect(explicitRoot.querySelector).toHaveBeenCalledWith(
+      '[data-mutiny-voice-control="toggleMute"]',
+    );
+  });
+
   it.each([
     ["toggleMute", "mic"],
     ["toggleMute", "mic_off"],
@@ -32,7 +50,9 @@ describe("voice control contract", () => {
   it("keeps accessible-label compatibility for hosted client variants", () => {
     const target = button("");
     const accessibleRoot = {
-      querySelector: vi.fn(() => target),
+      querySelector: vi.fn((selector: string) =>
+        selector.includes('button[title*="Disconnect"]') ? target : null,
+      ),
       querySelectorAll: (): ReturnType<typeof button>[] => [],
     };
     expect(executeVoiceControl(accessibleRoot, "disconnect")).toBe(

--- a/tests/voiceControl.test.ts
+++ b/tests/voiceControl.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { executeVoiceControl } from "../src/native/voiceControl";
+
+function button(symbol: string) {
+  return { textContent: symbol, click: vi.fn(), disabled: false };
+}
+
+function root(...buttons: ReturnType<typeof button>[]) {
+  return { querySelectorAll: () => buttons };
+}
+
+describe("voice control contract", () => {
+  it.each([
+    ["toggleMute", "mic"],
+    ["toggleMute", "mic_off"],
+    ["toggleDeafen", "headset"],
+    ["toggleDeafen", "headset_off"],
+    ["disconnect", "call_end"],
+  ] as const)("maps %s to the hosted client's %s symbol", (action, symbol) => {
+    const target = button(symbol);
+    expect(executeVoiceControl(root(target), action)).toBe(`clicked:${symbol}`);
+    expect(target.click).toHaveBeenCalledOnce();
+  });
+
+  it("returns not-found and does not click unrelated controls", () => {
+    const camera = button("camera_video");
+    expect(executeVoiceControl(root(camera), "toggleMute")).toBe("not-found");
+    expect(camera.click).not.toHaveBeenCalled();
+  });
+
+  it("keeps accessible-label compatibility for hosted client variants", () => {
+    const target = button("");
+    const accessibleRoot = {
+      querySelector: vi.fn(() => target),
+      querySelectorAll: (): ReturnType<typeof button>[] => [],
+    };
+    expect(executeVoiceControl(accessibleRoot, "disconnect")).toBe(
+      "clicked:accessible-label",
+    );
+    expect(target.click).toHaveBeenCalledOnce();
+    expect(accessibleRoot.querySelector).toHaveBeenCalledWith(
+      expect.stringContaining('button[title*="Disconnect"]'),
+    );
+  });
+});

--- a/tests/windowControls.test.ts
+++ b/tests/windowControls.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerWindowControlHandlers } from "../src/native/windowControls";
+
+class FakeIpc {
+  listeners = new Map<string, Array<() => void>>();
+  on(name: string, listener: () => void) {
+    this.listeners.set(name, [...(this.listeners.get(name) ?? []), listener]);
+  }
+  emit(name: string) {
+    for (const listener of this.listeners.get(name) ?? []) listener();
+  }
+}
+
+describe("window control IPC", () => {
+  it("registers one listener per command across window recreation", () => {
+    const ipc = new FakeIpc();
+    let current = {
+      minimize: vi.fn(), close: vi.fn(), maximize: vi.fn(), unmaximize: vi.fn(), isMaximized: vi.fn(() => false), isDestroyed: vi.fn(() => false),
+    };
+
+    registerWindowControlHandlers(ipc, () => current);
+    registerWindowControlHandlers(ipc, () => current);
+    expect(ipc.listeners.get("maximise")).toHaveLength(1);
+
+    ipc.emit("maximise");
+    expect(current.maximize).toHaveBeenCalledOnce();
+
+    current = { ...current, maximize: vi.fn(), isMaximized: vi.fn(() => true) };
+    ipc.emit("maximise");
+    expect(current.unmaximize).toHaveBeenCalledOnce();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "baseUrl": ".",
     "outDir": "dist",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "types": ["electron-vite/node"]
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Summary
- harden startup, autostart, single-instance, window, badge, screen-picker, and native configuration behavior
- secure the loopback control server with explicit policy and bounded request handling
- add native voice controls and deterministic Stream Deck integration
- add focused regression coverage and CI gates

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run package -- --arch=arm64 --platform=darwin`
- packaged app verified at `out/Mutiny-darwin-arm64/Mutiny.app`
- `git diff --check`

Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30

## Release candidate
- Version: v1.2.4
- Release workflow enforces package/version parity, reruns lint/typecheck/tests, builds macOS arm64 and Windows x64 artifacts, and publishes SHA-256 checksums.
- macOS artifacts are ad-hoc signed; Apple notarization is not configured. Windows artifacts are unsigned unless repository signing credentials are added.